### PR TITLE
Simplify ELevel dataclass

### DIFF
--- a/docs/modules/python/partials/api/data.adoc
+++ b/docs/modules/python/partials/api/data.adoc
@@ -1321,8 +1321,8 @@ Generate simple plot for this curve using matplotlib.
 
 *Returns:*
 
-* *fig* (link:#matplotlib.fig.Figure[Figure]) – Matplotlib figure. Use
-`fig.show()` to render plot.
+* *fig* (link:#fig.Figure[Figure]) – Matplotlib figure. Use `fig.show()`
+to render plot.
 
 === `Measurement`
 
@@ -1840,6 +1840,13 @@ to_dataframe()
 ----
 
 Return dataset as pandas dataframe.
+
+Requires pandas.
+
+*Returns:*
+
+* *df* (link:#pandas.DataFrame[DataFrame]) – pandas dataframe with all
+arrays in dataset
 
 === `EISData`
 

--- a/docs/modules/python/partials/api/fitting.adoc
+++ b/docs/modules/python/partials/api/fitting.adoc
@@ -140,9 +140,9 @@ Calculate observed and calculated Bode curve Z vs Frequency.
 * link:#pypalmsens.fitting.FitResult.get_bode_phase[*get++_++bode++_++phase*]
 – Calculate observed and calculated Bode curve phase vs Frequency.
 * link:#pypalmsens.fitting.FitResult.plot_nyquist[*plot++_++nyquist*] –
-Make nyquist plot.
+Make nyquist plot using matplotlib.
 * link:#pypalmsens.fitting.FitResult.plot_bode[*plot++_++bode*] – Make
-bode plot.
+bode plot using matplotlib.
 
 *Attributes:*
 
@@ -309,7 +309,7 @@ data.
 plot_nyquist(data)
 ----
 
-Make nyquist plot.
+Make nyquist plot using matplotlib.
 
 *Parameters:*
 
@@ -318,8 +318,8 @@ data.
 
 *Returns:*
 
-* *fig* (link:#matplotlib.fig.Figure[Figure]) – Returns matplotlib
-figure object. use `fig.show()` to render plot.
+* *fig* (link:#fig.Figure[Figure]) – Returns matplotlib figure object.
+use `fig.show()` to render plot.
 
 ==== `plot++_++bode`
 
@@ -328,7 +328,7 @@ figure object. use `fig.show()` to render plot.
 plot_bode(data)
 ----
 
-Make bode plot.
+Make bode plot using matplotlib.
 
 *Parameters:*
 
@@ -337,8 +337,8 @@ data.
 
 *Returns:*
 
-* *fig* (link:#matplotlib.fig.Figure[Figure]) – Returns matplotlib
-figure object. use `fig.show()` to render plot.
+* *fig* (link:#fig.Figure[Figure]) – Returns matplotlib figure object.
+use `fig.show()` to render plot.
 
 === `CircuitModel`
 

--- a/docs/modules/python/partials/api/settings.adoc
+++ b/docs/modules/python/partials/api/settings.adoc
@@ -319,7 +319,7 @@ Use `CURRENT++_++RANGE` to define the range.
 
 [source,python]
 ----
-ELevel(level=0.0, duration=1.0, record=True, use_limit_current_max=False, limit_current_max=0.0, use_limit_current_min=False, limit_current_min=0.0, trigger_at_level=False, trigger_at_level_lines=(False, False, False, False))
+ELevel(level=0.0, duration=1.0, record=True, limit_current_max=None, limit_current_min=None, trigger_lines=list())
 ----
 
 Create a multi-step amperometry level method object.
@@ -338,19 +338,17 @@ Level in V.
 (link:#float[float]) – Duration in s.
 * link:#pypalmsens.settings.ELevel.record[*record*] (link:#bool[bool]) –
 Record the current.
-* link:#pypalmsens.settings.ELevel.use_limit_current_max[*use++_++limit++_++current++_++max*]
-(link:#bool[bool]) – Use limit current max.
 * link:#pypalmsens.settings.ELevel.limit_current_max[*limit++_++current++_++max*]
-(link:#float[float]) – Limit current max in µA.
-* link:#pypalmsens.settings.ELevel.use_limit_current_min[*use++_++limit++_++current++_++min*]
-(link:#bool[bool]) – Use limit current min.
+(link:#float[float] ++|++ None) – Limit current max in µA. Set to None
+to disable.
 * link:#pypalmsens.settings.ELevel.limit_current_min[*limit++_++current++_++min*]
-(link:#float[float]) – Limit current min in µA.
-* link:#pypalmsens.settings.ELevel.trigger_at_level[*trigger++_++at++_++level*]
-(link:#bool[bool]) – Use trigger at level.
-* link:#pypalmsens.settings.ELevel.trigger_at_level_lines[*trigger++_++at++_++level++_++lines*]
-(link:#tuple[tuple]++[++link:#bool[bool], link:#bool[bool],
-link:#bool[bool], link:#bool[bool]++]++) – Trigger at level lines.
+(link:#float[float] ++|++ None) – Limit current min in µA. Set to None
+to disable.
+* link:#pypalmsens.settings.ELevel.trigger_lines[*trigger++_++lines*]
+(link:#typing.Sequence[Sequence]++[++link:#typing.Literal[Literal]++[++0,
+1, 2, 3++]]++) – Trigger at level lines.
+* link:#pypalmsens.settings.ELevel.use_limits[*use++_++limits*]
+(link:#bool[bool]) – Return True if instance sets current limits.
 
 ==== `level`
 
@@ -379,61 +377,44 @@ record: bool = True
 
 Record the current.
 
-==== `use++_++limit++_++current++_++max`
-
-[source,python]
-----
-use_limit_current_max: bool = False
-----
-
-Use limit current max.
-
 ==== `limit++_++current++_++max`
 
 [source,python]
 ----
-limit_current_max: float = 0.0
+limit_current_max: float | None = None
 ----
 
-Limit current max in µA.
-
-==== `use++_++limit++_++current++_++min`
-
-[source,python]
-----
-use_limit_current_min: bool = False
-----
-
-Use limit current min.
+Limit current max in µA. Set to None to disable.
 
 ==== `limit++_++current++_++min`
 
 [source,python]
 ----
-limit_current_min: float = 0.0
+limit_current_min: float | None = None
 ----
 
-Limit current min in µA.
+Limit current min in µA. Set to None to disable.
 
-==== `trigger++_++at++_++level`
+==== `trigger++_++lines`
 
 [source,python]
 ----
-trigger_at_level: bool = False
-----
-
-Use trigger at level.
-
-==== `trigger++_++at++_++level++_++lines`
-
-[source,python]
-----
-trigger_at_level_lines: tuple[bool, bool, bool, bool] = (False, False, False, False)
+trigger_lines: Sequence[Literal[0, 1, 2, 3]] = field(default_factory=list)
 ----
 
 Trigger at level lines.
 
-Line order : ++[++d0 high, d1 high, d2 high, d3 high++]++
+Set digital output lines at start of measurement, end of equilibration.
+Accepted values: 0 for d0, 1 for d1, 2 for d2, 3 for d3.
+
+==== `use++_++limits`
+
+[source,python]
+----
+use_limits: bool
+----
+
+Return True if instance sets current limits.
 
 ==== `to++_++psobj`
 

--- a/python/src/pypalmsens/_methods/_shared.py
+++ b/python/src/pypalmsens/_methods/_shared.py
@@ -178,18 +178,26 @@ class ELevel:
     record: bool = True
     """Record the current."""
 
-    limit_current_max: float | None = 0.0
+    limit_current_max: float | None = None
     """Limit current max in µA. Set to None to disable."""
 
-    limit_current_min: float | None = 0.0
+    limit_current_min: float | None = None
     """Limit current min in µA. Set to None to disable."""
 
-    trigger_lines: Sequence[Literal[0, 1, 2, 3]] = field(default_factory=tuple)
+    trigger_lines: Sequence[Literal[0, 1, 2, 3]] = field(default_factory=list)
     """Trigger at level lines.
 
     Set digital output lines at start of measurement, end of equilibration.
     Accepted values: 0 for d0, 1 for d1, 2 for d2, 3 for d3.
     """
+
+    @property
+    def use_limits(self) -> bool:
+        """Return True if instance sets current limits."""
+        use_limit_current_min = self.limit_current_min is not None
+        use_limit_current_max = self.limit_current_max is not None
+
+        return use_limit_current_min or use_limit_current_max
 
     def to_psobj(self):
         obj = PalmSens.Techniques.ELevel()
@@ -205,9 +213,9 @@ class ELevel:
 
         obj.UseTriggerOnStart = bool(self.trigger_lines)
 
-        trigger_at_level_lines = [(val in self.trigger_lines) for val in (0, 1, 2, 3)]
+        trigger_bools = [(val in self.trigger_lines) for val in (0, 1, 2, 3)]
 
-        obj.TriggerValueOnStart = convert_bools_to_int(trigger_at_level_lines)
+        obj.TriggerValueOnStart = convert_bools_to_int(trigger_bools)
 
         return obj
 

--- a/python/src/pypalmsens/_methods/_shared.py
+++ b/python/src/pypalmsens/_methods/_shared.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Sequence
+from typing import Any, Literal, Sequence
 
 import PalmSens
 
@@ -178,25 +178,18 @@ class ELevel:
     record: bool = True
     """Record the current."""
 
-    use_limit_current_max: bool = False
-    """Use limit current max."""
+    limit_current_max: float | None = 0.0
+    """Limit current max in µA. Set to None to disable."""
 
-    limit_current_max: float = 0.0
-    """Limit current max in µA."""
+    limit_current_min: float | None = 0.0
+    """Limit current min in µA. Set to None to disable."""
 
-    use_limit_current_min: bool = False
-    """Use limit current min."""
-
-    limit_current_min: float = 0.0
-    """Limit current min in µA."""
-
-    trigger_at_level: bool = False
-    """Use trigger at level."""
-
-    trigger_at_level_lines: tuple[bool, bool, bool, bool] = (False, False, False, False)
+    trigger_lines: Sequence[Literal[0, 1, 2, 3]] = field(default_factory=tuple)
     """Trigger at level lines.
 
-    Line order : [d0 high, d1 high, d2 high, d3 high]"""
+    Set digital output lines at start of measurement, end of equilibration.
+    Accepted values: 0 for d0, 1 for d1, 2 for d2, 3 for d3.
+    """
 
     def to_psobj(self):
         obj = PalmSens.Techniques.ELevel()
@@ -205,27 +198,35 @@ class ELevel:
         obj.Duration = self.duration
         obj.Record = self.record
 
-        obj.UseMaxLimit = self.use_limit_current_max
-        obj.MaxLimit = self.limit_current_max
-        obj.UseMinLimit = self.use_limit_current_min
-        obj.MinLimit = self.limit_current_min
+        obj.UseMaxLimit = self.limit_current_max is not None
+        obj.MaxLimit = self.limit_current_max or 0.0
+        obj.UseMinLimit = self.limit_current_min is not None
+        obj.MinLimit = self.limit_current_min or 0.0
 
-        obj.UseTriggerOnStart = self.trigger_at_level
-        obj.TriggerValueOnStart = convert_bools_to_int(self.trigger_at_level_lines)
+        obj.UseTriggerOnStart = bool(self.trigger_lines)
+
+        trigger_at_level_lines = [(val in self.trigger_lines) for val in (0, 1, 2, 3)]
+
+        obj.TriggerValueOnStart = convert_bools_to_int(trigger_at_level_lines)
 
         return obj
 
     @classmethod
     def from_psobj(cls, psobj: PalmSens.Techniques.ELevel):
         """Construct ELevel dataclass from PalmSens.Techniques.ELevel object."""
+        trigger_lines: list[Literal[0, 1, 2, 3]] = []
+
+        if psobj.UseTriggerOnStart:
+            trigger_bools = convert_int_to_bools(psobj.TriggerValueOnStart)
+            for i in (0, 1, 2, 3):
+                if trigger_bools[i]:
+                    trigger_lines.append(i)
+
         return cls(
             level=single_to_double(psobj.Level),
             duration=single_to_double(psobj.Duration),
             record=psobj.Record,
-            use_limit_current_max=psobj.UseMaxLimit,
-            limit_current_max=single_to_double(psobj.MaxLimit),
-            use_limit_current_min=psobj.UseMinLimit,
-            limit_current_min=single_to_double(psobj.MinLimit),
-            trigger_at_level=psobj.UseTriggerOnStart,
-            trigger_at_level_lines=convert_int_to_bools(psobj.TriggerValueOnStart),
+            limit_current_max=single_to_double(psobj.MaxLimit) if psobj.MaxLimit else None,
+            limit_current_min=single_to_double(psobj.MinLimit) if psobj.MinLimit else None,
+            trigger_lines=trigger_lines,
         )

--- a/python/src/pypalmsens/_methods/techniques.py
+++ b/python/src/pypalmsens/_methods/techniques.py
@@ -698,10 +698,7 @@ class MultiStepAmperometry(
             obj.Levels.Add(level.to_psobj())
 
         obj.UseSelectiveRecord = any(level.record for level in self.levels)
-        obj.UseLimits = any(
-            (level.use_limit_current_min or level.use_limit_current_max)
-            for level in self.levels
-        )
+        obj.UseLimits = any(level.use_limits for level in self.levels)
 
         set_extra_value_mask(
             obj=obj,


### PR DESCRIPTION
This PR makes the ELevels a bit easier to configure, especially the level lines and current limits:

```python
elevel = ELevel(
    level = 0.0,
    duration = 1.0,
    limit_current_max=0.1,   # set to 0.1
    limit_current_min=None,  # disabled
    trigger_lines=[0, 1],    # trigger at lines d0 and d1
)
```



Closes #73 