### PR TITLE
Force re-checkout of the updated tag

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -57,6 +57,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+        ref: ${{ github.ref_name }}
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
This PR forces GA to checkout the updated tag with the version bumped. In the previous version, it would checkout the ref associated with the 'unbumped' commit.