### PR TITLE
Release winforms-1.0.0

### DIFF
--- a/docs/start/modules/ROOT/pages/releases.adoc
+++ b/docs/start/modules/ROOT/pages/releases.adoc
@@ -2,6 +2,7 @@ Releases
 ========
 
 // latest
+- https://github.com/palmsens/palmsens_sdk/releases/tag/winforms-1.0.0[winforms-1.0.0]
 - https://github.com/palmsens/palmsens_sdk/releases/tag/python-1.6.0[python-1.6.0]
 - https://github.com/palmsens/palmsens_sdk/releases/tag/python-1.5.0[python-1.5.0]
 - https://github.com/palmsens/palmsens_sdk/releases/tag/maui-1.2.3[maui-1.2.3]


### PR DESCRIPTION
This PR prepares for a new release of the winforms SDK.

- branch: `release-winforms-1.0.0`
- version: `1.0.0`
- sdk: `winforms`
