### PR TITLE
Update links to driver installer

### DIFF
--- a/labview/docs/modules/ROOT/pages/installation.adoc
+++ b/labview/docs/modules/ROOT/pages/installation.adoc
@@ -9,7 +9,7 @@ This page takes you through setting up the SDK for your LabVIEW project.
   - The code was developed with Community Version 2025
   - For compatibility with older versions (down to 2019), use menu:File[Save for previous versions].
 * .NET Framework 4.7.2
-* Drivers included with PSTrace 5, MultiTrace 4, PSTrace Xpress or the https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[driver installer].
+* Drivers included with PSTrace 5, MultiTrace 4, PSTrace Xpress or the https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[driver installer].
 
 Download the latest https://github.com/palmsens/palmsens_sdk/releases[release here].
 Unzip the file and load the project file in Labview.
@@ -57,7 +57,7 @@ See the chapter 'Updating firmware' in the https://www.palmsens.com/knowledgebas
 
 | Nexus
 | 1.100
-| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[the driver installer].]
+| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[the driver installer].]
 
 | Palmsens1
 | 4.4

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -27,7 +27,7 @@ For more information, see the [documentation](https://sdk.palmsens.com/matlab/la
 
 - [Matlab (R2018 or newer)](https://nl.mathworks.com/products/matlab.html)
 - .NET Framework 4.7.2
-- Drivers included with PSTrace 5, MultiTrace 4, PSTrace Xpress or the [driver installer](https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe).
+- Drivers included with PSTrace 5, MultiTrace 4, PSTrace Xpress or the [driver installer](https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe).
 
 Download the latest [release here](https://github.com/palmsens/palmsens_sdk/releases).
 Unzip the file and load the directory 'matlab-x.y.z' in Matlab.

--- a/matlab/docs/modules/ROOT/pages/index.adoc
+++ b/matlab/docs/modules/ROOT/pages/index.adoc
@@ -35,7 +35,7 @@ You can plot the results of your electrochemical experiment in a Nyquist and Bod
 
 * https://nl.mathworks.com/products/matlab.html[Matlab (R2018 or newer)]
 * .NET Framework 4.7.2
-* Drivers included with PSTrace 5, MultiTrace 4, PSTrace Xpress or the https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[driver installer].
+* Drivers included with PSTrace 5, MultiTrace 4, PSTrace Xpress or the https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[driver installer].
 
 Download the latest https://github.com/palmsens/palmsens_sdk/releases[release here].
 Unzip the file and load the directory 'matlab-x.y.z' in Matlab.
@@ -57,7 +57,7 @@ See the chapter 'Updating firmware' in the https://www.palmsens.com/knowledgebas
 
 | Nexus
 | 1.100
-| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[the driver installer].]
+| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[the driver installer].]
 
 | Palmsens1
 | 4.4

--- a/maui/docs/modules/ROOT/pages/installation.adoc
+++ b/maui/docs/modules/ROOT/pages/installation.adoc
@@ -57,7 +57,7 @@ See the chapter 'Updating firmware' in the https://www.palmsens.com/knowledgebas
 
 | Nexus
 | 1.100
-| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[the driver installer].]
+| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[the driver installer].]
 
 | Palmsens1
 | 4.4

--- a/python/docs/modules/ROOT/pages/installation.adoc
+++ b/python/docs/modules/ROOT/pages/installation.adoc
@@ -11,7 +11,7 @@ pip install pypalmsens
 
 * https://python.org[Python version 3.10 or newer]
 * .NET Framework 4.7.2
-* Drivers included with PSTrace 5, MultiTrace 4, PSTrace Xpress or the https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[driver installer].
+* Drivers included with PSTrace 5, MultiTrace 4, PSTrace Xpress or the https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[driver installer].
 
 [#req-linux]
 == Requirements (Linux and MacOS)
@@ -197,7 +197,7 @@ See the chapter 'Updating firmware' in the https://www.palmsens.com/knowledgebas
 
 | Nexus
 | 1.100
-| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[the driver installer].]
+| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[the driver installer].]
 | n/a footnote:linuxserial[The SDK communicates directly via the serial port. No drivers are necessary.]
 
 | Palmsens1

--- a/winforms/docs/modules/ROOT/pages/installation.adoc
+++ b/winforms/docs/modules/ROOT/pages/installation.adoc
@@ -74,7 +74,7 @@ See the chapter 'Updating firmware' in the https://www.palmsens.com/knowledgebas
 
 | Nexus
 | 1.100
-| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[the driver installer].]
+| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[the driver installer].]
 
 | Palmsens1
 | 4.4

--- a/wpf/docs/modules/ROOT/pages/installation.adoc
+++ b/wpf/docs/modules/ROOT/pages/installation.adoc
@@ -70,7 +70,7 @@ See the chapter 'Updating firmware' in the https://www.palmsens.com/knowledgebas
 
 | Nexus
 | 1.100
-| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/python-1.0.0/PalmSens.Drivers.exe[the driver installer].]
+| palmsens_cdc.inf (optional) footnote:psdrivers[Drivers are installed with alongside the PSTrace desktop software or using https://github.com/PalmSens/PalmSens_SDK/releases/download/drivers-5.12/PalmSens.Drivers.exe[the driver installer].]
 
 | Palmsens1
 | 4.4


### PR DESCRIPTION
I made a release for the [driver installer](https://github.com/PalmSens/PalmSens_SDK/releases/tag/drivers-5.12). This PR updates the links in the docs.

Closes #239 