### PR TITLE
Automatically mark methods that are not supported as skip

### DIFF
--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -26,7 +26,7 @@ from .callback import Callback, CallbackEIS, Status
 from .instrument import Instrument, discover
 from .instrument_manager_async import SupportedMixin
 from .measurement_manager_async import MeasurementManagerAsync
-from .shared import create_future, firmware_warning
+from .shared import MethodIncompatibleError, create_future, firmware_warning
 
 warnings.simplefilter('default')
 
@@ -306,7 +306,7 @@ class InstrumentManager(SupportedMixin):
     def validate_method(self, method: PalmSens.Method | BaseTechnique) -> None:
         """Validate method.
 
-        Raise ValueError if the method cannot be validated."""
+        Raise MethodIncompatibleError if the method cannot be validated."""
         self.ensure_connection()
 
         if not isinstance(method, PalmSens.Method):
@@ -316,7 +316,7 @@ class InstrumentManager(SupportedMixin):
 
         if any(error.IsFatal for error in errors):
             message = '\n'.join([error.Message for error in errors])
-            raise ValueError(f'Method not compatible:\n{message}')
+            raise MethodIncompatibleError(f'Method not compatible:\n{message}')
 
     def measure(
         self,

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -28,7 +28,7 @@ from ..data import Measurement
 from .callback import Callback, CallbackEIS, CallbackStatus, Status
 from .instrument import Instrument, discover_async
 from .measurement_manager_async import MeasurementManagerAsync
-from .shared import create_future, firmware_warning
+from .shared import MethodIncompatibleError, create_future, firmware_warning
 
 WINDOWS = sys.platform == 'win32'
 LINUX = not WINDOWS
@@ -443,7 +443,7 @@ class InstrumentManagerAsync(SupportedMixin):
 
         if any(error.IsFatal for error in errors):
             message = '\n'.join([error.Message for error in errors])
-            raise ValueError(f'Method not compatible:\n{message}')
+            raise MethodIncompatibleError(f'Method not compatible:\n{message}')
 
     async def measure(
         self,

--- a/python/src/pypalmsens/_instruments/shared.py
+++ b/python/src/pypalmsens/_instruments/shared.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 
 
+class MethodIncompatibleError(ValueError): ...
+
+
 def create_future(clr_task: System.Task[T]) -> asyncio.Future[T]:
     loop = asyncio.get_running_loop()
     future = loop.create_future()

--- a/python/tests/test_techniques.py
+++ b/python/tests/test_techniques.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 import pypalmsens as ps
+from pypalmsens._instruments.shared import MethodIncompatibleError
 from pypalmsens._methods import BaseTechnique
 from pypalmsens.data import DataArray, DataSet
 
@@ -1245,7 +1246,19 @@ class MM:
 def test_measure(manager, method):
     params = BaseTechnique._registry[method.id].from_dict(method.kwargs)
 
-    measurement = manager.measure(params)
+    try:
+        measurement = manager.measure(params)
+    except MethodIncompatibleError as exc:
+        message = str(exc)
+        if (
+            ('is not supported by this device.' in message)
+            or ('Fast Impedance techniques are only supported by' in message)
+            or ('Fast Galvanostatic Impedance techniques are only supported by' in message)
+        ):
+            pytest.skip(f'{manager.instrument.name} does not support {method.id!r}')
+        if 'Contact PalmSens BV or your local distributor to upgrade your license.' in message:
+            pytest.skip(f'Unlicensed method: {method.id!r}')
+        raise
 
     method.validate(measurement)
 

--- a/python/tests/test_techniques_async.py
+++ b/python/tests/test_techniques_async.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 from test_techniques import CP, CV, EIS, MM, MS
 
 import pypalmsens as ps
+from pypalmsens._instruments.shared import MethodIncompatibleError
 from pypalmsens._methods import BaseTechnique
 from pypalmsens.data import DataArray, DataSet
 
@@ -90,7 +91,20 @@ async def test_read_potential(manager):
 )
 async def test_measure(manager, method):
     params = BaseTechnique._registry[method.id].from_dict(method.kwargs)
-    measurement = await manager.measure(params)
+
+    try:
+        measurement = await manager.measure(params)
+    except MethodIncompatibleError as exc:
+        message = str(exc)
+        if (
+            ('is not supported by this device.' in message)
+            or ('Fast Impedance techniques are only supported by' in message)
+            or ('Fast Galvanostatic Impedance techniques are only supported by' in message)
+        ):
+            pytest.skip(f'{manager.instrument.name} does not support {method.id!r}')
+        if 'Contact PalmSens BV or your local distributor to upgrade your license.' in message:
+            pytest.skip(f'Unlicensed method: {method.id!r}')
+        raise
 
     method.validate(measurement)
 


### PR DESCRIPTION
This PR solves the issue that not all devices support all methods. Instead of outright failing, check whether the device supports the method. If the method is not supported (and therefore can never succeed), mark the test as 'skip'.

Closes #193 