### PR TITLE
Add retry function to `pool.connect()`

### DIFF
--- a/python/docs/zensical/measuring.md
+++ b/python/docs/zensical/measuring.md
@@ -166,6 +166,25 @@ NEXUS24C0029
     Connecting to a device over TCP/IP is available on Windows only.
     See https://github.com/PalmSens/PalmSens_SDK/issues/327 for more info.
 
+### Connection issues
+
+In some cases, devices may fail to connect via USB at seemingly random moments with the following error message:
+
+```
+Palmsens connection error: Device not recognized
+```
+
+This error means that the channel has been discovered, the connection has been opened, but that it was somehow not possible to send/receive data.
+This can happen when there is some interference. Especially when establishing a connection there is a lot of back-and-forth communication, so chances of interference are the largest.
+Unfortunately, there is no guarantee that the USB connection is stable with every PC configuration.
+
+However, there are some precautions you can take.
+
+1. Use the original USB cable as some other cables may not be properly shielded.
+2. If you connect a MultiPalmSens4 via USB, wait at least 30s up to a minute before connecting after turning it on.
+
+In most cases, you can simply retry connecting to the device or the channels.
+If you are using an `InstrumentPool`, you can increase the number of attempts to establish the connection, see [InstrumentPool.connect][pypalmsens.InstrumentPool.connect] / [InstrumentPoolAsync.connect][pypalmsens.InstrumentPoolAsync.connect].
 
 ## Measuring
 

--- a/python/src/pypalmsens/_instruments/instrument_pool.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool.py
@@ -55,9 +55,13 @@ class InstrumentPool:
     def __iter__(self):
         yield from self.managers
 
-    def connect(self) -> None:
-        """Connect all instrument managers in the pool."""
-        self._loop.run_until_complete(self._async.connect())
+    def connect(self, attempts: int = 1) -> None:
+        """Connect all instrument managers in the pool.
+
+        attempts: int, optional
+            Number of attempts to establish connection.
+        """
+        self._loop.run_until_complete(self._async.connect(attempts=attempts))
 
     def disconnect(self) -> None:
         """Disconnect all instrument managers in the pool."""

--- a/python/src/pypalmsens/_instruments/instrument_pool.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool.py
@@ -58,8 +58,11 @@ class InstrumentPool:
     def connect(self, attempts: int = 1) -> None:
         """Connect all instrument managers in the pool.
 
+        Parameters
+        ----------
         attempts: int, optional
             Number of attempts to establish connection.
+            Use this if you experience connection issues via USB.
         """
         self._loop.run_until_complete(self._async.connect(attempts=attempts))
 

--- a/python/src/pypalmsens/_instruments/instrument_pool_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool_async.py
@@ -58,10 +58,24 @@ class InstrumentPoolAsync:
     def __iter__(self):
         yield from self.managers
 
-    async def connect(self) -> None:
-        """Connect all instrument managers in the pool."""
+    async def connect(self, attempts: int = 1) -> None:
+        """Connect all instrument managers in the pool.
+
+        attempts: int, optional
+            Number of attempts to establish connection.
+        """
         tasks = [manager.connect() for manager in self.managers]
-        await asyncio.gather(*tasks)
+
+        try:
+            _ = await asyncio.gather(*tasks)
+        except Exception:
+            if attempts <= 0:
+                raise
+            await asyncio.sleep(0.5)
+        else:
+            return
+
+        await self.connect(attempts=attempts - 1)
 
     async def disconnect(self) -> None:
         """Disconnect all instrument managers in the pool."""

--- a/python/src/pypalmsens/_instruments/instrument_pool_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool_async.py
@@ -61,15 +61,18 @@ class InstrumentPoolAsync:
     async def connect(self, attempts: int = 1) -> None:
         """Connect all instrument managers in the pool.
 
+        Parameters
+        ----------
         attempts: int, optional
             Number of attempts to establish connection.
+            Use this if you experience connection issues via USB.
         """
         tasks = [manager.connect() for manager in self.managers]
 
         try:
             _ = await asyncio.gather(*tasks)
         except Exception:
-            if attempts <= 0:
+            if attempts <= 1:
                 raise
             await asyncio.sleep(0.5)
         else:


### PR DESCRIPTION
This PR adds a retry function to help establishing a connection.

Closes #332

### TODO

- [x] Catch specific error
- [x] Consider timeout instead of attempts?
- [x] Update docstring with context (why is this needed?)
- [ ] ~Enable context manager via:~

```python
with ps.connect(pool, attempts=5):
    ....
# or 
with pool.connect(attempts=5):
    ....
```