### PR TITLE
Fix `DataSet.to_dict()` crash for datasets with no current

### DIFF
--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -214,11 +214,14 @@ class DataSet(Mapping[str, DataArray]):
         """
         dct: dict[str, Any] = {key: arr.to_list() for key, arr in self.items() if len(arr)}
 
-        current = self.arrays(type='Current')[-1]
-        assert isinstance(current, CurrentArray)
-
-        dct['CR'] = current.current_range()
-        dct['ReadingStatus'] = current.reading_status()
+        try:
+            current = self.arrays(type='Current')[-1]
+            assert isinstance(current, CurrentArray)
+        except IndexError:  # e.g. OCP does not have a current array
+            pass
+        else:
+            dct['CR'] = current.current_range()
+            dct['ReadingStatus'] = current.reading_status()
 
         return dct
 

--- a/python/src/pypalmsens/_methods/techniques.py
+++ b/python/src/pypalmsens/_methods/techniques.py
@@ -1771,14 +1771,14 @@ class ElectrochemicalImpedanceSpectroscopy(
     """
 
     run_time: float = 10.0
-    """Minimal run time in seconds (time scan only).
+    """Minimal run time in seconds in s (time scan only).
 
     For example, if a frequency scan takes 18 seconds and is measured
     at an interval of 19 seconds for a `run_time` of 40 seconds, then
     three iterations will be performed."""
 
     interval_time: float = 0.1
-    """The interval at which a measurement iteration should be performed (time scan only).
+    """The interval at which a measurement iteration should be performed in s (time scan only).
 
     The minimum interval time between each data point (`frequency_type='fixed') or
     between each frequency scan (`frequency_type='scan').


### PR DESCRIPTION
This PR fixes a crash when calling `DataSet.to_dict()` on an OCP measurement.

Closes #336 