### PR TITLE
Move `get_estimated_duration` to instrument manager

### DIFF
--- a/python/src/pypalmsens/_data/method.py
+++ b/python/src/pypalmsens/_data/method.py
@@ -40,21 +40,6 @@ class Method:
             return Path(fn)
         return None
 
-    def get_estimated_duration(self, *, instrument_manager=None):
-        """Get the estimated duration for this method.
-
-        Parameters
-        ----------
-        instrument_manager : InstrumentManager
-            Specifies the instrument manager to get the connected instruments capabilities from,
-            If not specified it will use the PalmSens4 capabilities to determine the estimated duration.
-        """
-        if instrument_manager is None or instrument_manager.__comm is None:
-            instrument_capabilities = PalmSens.Devices.PalmSens4Capabilities()
-        else:
-            instrument_capabilities = instrument_manager.__comm.Capabilities
-        return self._psmethod.GetMinimumEstimatedMeasurementDuration(instrument_capabilities)
-
     @property
     def supports_corrosion(self) -> bool:
         """Return true if corrosion is supported."""

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -23,9 +23,9 @@ from .._methods import (
 from ..data import Measurement
 from .callback import Callback, CallbackEIS, Status
 from .instrument import Instrument, discover
-from .instrument_manager_async import SupportedMixin
+from .instrument_manager_async import MethodHelpersMixin, SupportedMixin
 from .measurement_manager_async import MeasurementManagerAsync
-from .shared import MethodIncompatibleError, firmware_warning
+from .shared import firmware_warning
 
 warnings.simplefilter('default')
 
@@ -100,7 +100,7 @@ def measure(
     return measurement
 
 
-class InstrumentManager(SupportedMixin):
+class InstrumentManager(SupportedMixin, MethodHelpersMixin):
     """Instrument manager for PalmSens instruments.
 
     Parameters
@@ -288,21 +288,6 @@ class InstrumentManager(SupportedMixin):
             serial = self._comm.DeviceSerial.ToString()
 
         return serial
-
-    def validate_method(self, method: PalmSens.Method | BaseTechnique) -> None:
-        """Validate method.
-
-        Raise MethodIncompatibleError if the method cannot be validated."""
-        self.ensure_connection()
-
-        if not isinstance(method, PalmSens.Method):
-            method = method._to_psmethod()
-
-        errors = method.Validate(self._comm.Capabilities)
-
-        if any(error.IsFatal for error in errors):
-            message = '\n'.join([error.Message for error in errors])
-            raise MethodIncompatibleError(f'Method not compatible:\n{message}')
 
     def measure(
         self,

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -188,7 +188,58 @@ class SupportedMixin:
         return [pr_enum_to_string(pr) for pr in capabilities.SupportedPotentialRanges]
 
 
-class InstrumentManagerAsync(SupportedMixin):
+class MethodHelpersMixin:
+    def get_estimated_duration(
+        self: HasCommProtocol,
+        method: PalmSens.Method | BaseTechnique,
+    ) -> float:
+        """Get the estimated duration for this method.
+
+        Parameters
+        -----------
+        method : Method parameters
+            The method to get the estimated duration for.
+
+        Returns
+        -------
+        float
+            Estimated duration in seconds.
+        """
+        self.ensure_connection()
+
+        if not isinstance(method, PalmSens.Method):
+            method = method._to_psmethod()
+
+        instrument_capabilities = self._comm.Capabilities
+
+        return method.GetMinimumEstimatedMeasurementDuration(instrument_capabilities)
+
+    def validate_method(
+        self: HasCommProtocol,
+        method: PalmSens.Method | BaseTechnique,
+    ) -> None:
+        """Validate method.
+
+        Raise ValueError if the method cannot be validated.
+
+        Parameters
+        -----------
+        method : Method parameters
+            The method to validate.
+        """
+        self.ensure_connection()
+
+        if not isinstance(method, PalmSens.Method):
+            method = method._to_psmethod()
+
+        errors = method.Validate(self._comm.Capabilities)
+
+        if any(error.IsFatal for error in errors):
+            message = '\n'.join([error.Message for error in errors])
+            raise MethodIncompatibleError(f'Method not compatible:\n{message}')
+
+
+class InstrumentManagerAsync(MethodHelpersMixin, SupportedMixin):
     """Asynchronous instrument manager for PalmSens instruments.
 
     Parameters
@@ -417,21 +468,6 @@ class InstrumentManagerAsync(SupportedMixin):
 
         _ = self._loop.call_soon_threadsafe(self._status_callback, status)
         return Task.CompletedTask
-
-    def validate_method(self, method: PalmSens.Method | BaseTechnique) -> None:
-        """Validate method.
-
-        Raise ValueError if the method cannot be validated."""
-        self.ensure_connection()
-
-        if not isinstance(method, PalmSens.Method):
-            method = method._to_psmethod()
-
-        errors = method.Validate(self._comm.Capabilities)
-
-        if any(error.IsFatal for error in errors):
-            message = '\n'.join([error.Message for error in errors])
-            raise MethodIncompatibleError(f'Method not compatible:\n{message}')
 
     async def measure(
         self,

--- a/python/tests/test_instrument.py
+++ b/python/tests/test_instrument.py
@@ -230,3 +230,16 @@ async def test_supported_async():
         assert isinstance(manager.supported_applied_current_ranges(), list)
         assert isinstance(manager.supported_potential_ranges(), list)
         assert isinstance(manager.supported_bipot_ranges(), list)
+
+
+@pytest.mark.instrument
+@pytest.mark.asyncio
+async def test_get_estimated_duration():
+    instruments = await ps.discover_async()
+
+    method = ps.OpenCircuitPotentiometry(run_time=10)
+
+    async with await ps.connect_async(instruments[0]) as manager:
+        t = manager.get_estimated_duration(method)
+
+    assert t == pytest.approx(10.1)


### PR DESCRIPTION
This PR moves the `.get_estimated_duration()` method to a more accessible location, `InstrumentManager`/`InstrumentManagerAsync`.

```python
>>> import pypalmsens as ps

>>> method = ps.CyclicVoltammetry()

>>> with ps.connect() as manager:
...     print(manager.get_estimated_duration(method))
2.099
```