### PR TITLE
Work around page validation warnings in zensical 0.0.38

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -63,9 +63,9 @@ publishing = [
 ]
 
 docs = [
-    "zensical >= 0.0.20",
-    "mkdocstrings >= 1.0.1",
-    "mkdocstrings-python",
+    "zensical >= 0.0.38",
+    "mkdocstrings >= 1.0.4",
+    "mkdocstrings-python >= 2.0.3",
 ]
 
 [tool.setuptools]

--- a/python/zensical.toml
+++ b/python/zensical.toml
@@ -102,6 +102,9 @@ link = "https://pypi.org/project/pypalmsens/"
 icon = "fontawesome/solid/paper-plane"
 link = "https://www.palmsens.com/contact"
 
+[project.validation]
+unresolved_references = false
+
 [project.theme]
 name = "material"
 logo = "assets/header_icon_white.svg"

--- a/python/zensical.toml
+++ b/python/zensical.toml
@@ -104,6 +104,7 @@ link = "https://www.palmsens.com/contact"
 
 [project.validation]
 unresolved_references = false
+invalid_links = false  # https://github.com/zensical/zensical/issues/603
 
 [project.theme]
 name = "material"


### PR DESCRIPTION
This PR works around issues introduced by the new validation tool in zensical 0.0.38:

- release: https://github.com/zensical/zensical/releases/tag/v0.0.38
- docs: https://zensical.org/docs/setup/validation/

- issues: 
	- https://github.com/zensical/studio/issues/24
	- https://github.com/zensical/zensical/issues/603

