### PR TITLE
Use EILevel for MSP methods

### DIFF
--- a/docs/dotnet/modules/ROOT/pages/techniques.adoc
+++ b/docs/dotnet/modules/ROOT/pages/techniques.adoc
@@ -685,11 +685,11 @@ This value is multiplied by the defined current range.
 * `TechniqueID`: 13
 * `MethodID`: `"mp"`
 
-Create multi-step potentiometry method by specifying levels using `PalmSens.Techniques.ILevel`.
+Create multi-step potentiometry method by specifying levels using `PalmSens.Techniques.EILevel`.
 
 ----
 method = PalmSens.Techniques.MultistepPotentiometry();
-level = PalmSens.Techniques.ILevel();
+level = PalmSens.Techniques.EILevel();
 level.Duration = 2.0;
 level.Level = 1.0;
 method.Levels.Add(level);
@@ -720,9 +720,9 @@ method.Levels.Add(level);
 |`System.Bool`
 |===
 
-=== ILevel
+=== EILevel
 
-* Class: `PalmSens.Techniques.ILevel`
+* Class: `PalmSens.Techniques.EILevel`
 
 [cols="1,2,1"]
 |===

--- a/python/src/pypalmsens/_methods/levels.py
+++ b/python/src/pypalmsens/_methods/levels.py
@@ -131,8 +131,8 @@ class ILevel(BaseModel):
 
         return use_limit_potential_min or use_limit_potential_max
 
-    def to_psobj(self) -> PalmSens.Techniques.ELevel:
-        obj = PalmSens.Techniques.ELevel()
+    def to_psobj(self) -> PalmSens.Techniques.EILevel:
+        obj = PalmSens.Techniques.EILevel()
 
         obj.Level = self.level
         obj.Duration = self.duration

--- a/python/src/pypalmsens/_methods/levels.py
+++ b/python/src/pypalmsens/_methods/levels.py
@@ -152,7 +152,7 @@ class ILevel(BaseModel):
         return obj
 
     @classmethod
-    def from_psobj(cls, psobj: PalmSens.Techniques.ELevel):
+    def from_psobj(cls, psobj: PalmSens.Techniques.EILevel):
         """Construct ILevel dataclass from PalmSens.Techniques.ELevel object."""
         trigger_lines: list[Literal[0, 1, 2, 3]] = []
 


### PR DESCRIPTION
MSA uses `PalmSens.Technique.ELevel`
MSP uses `PalmSens.Technique.EILevel`

The Python code incorrectly uses `ELevel` for both MSA and MSP. This PR fixes the underlying class for `pypalmsens.settings.ILevel` to `PalmSens.Techniques.EILevel`.

This PR also updates the dotnet docs which refer to non-existent `ILevel` variable.

Closes #344

