### PR TITLE
Add __getitem__ and __contains__ magic methods to pool

### DIFF
--- a/python/src/pypalmsens/_instruments/instrument_pool.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from .._methods import BaseTechnique
 from .callback import Callback, CallbackEIS
@@ -19,8 +19,7 @@ class InstrumentPool:
     Most calls are run asynchronously in the background,
     which means that measurements are running in parallel.
 
-    This is a thin wrapper around the `InstrumentManagerAsync`.
-
+    This is a thin wrapper around the `InstrumentPoolAsync` class.
 
     Parameters
     ----------
@@ -54,6 +53,12 @@ class InstrumentPool:
 
     def __iter__(self):
         yield from self.managers
+
+    def __contains__(self, obj: Any):
+        return obj in self.managers
+
+    def __getitem__(self, index: int) -> InstrumentManagerAsync:
+        return self.managers[index]
 
     def connect(self, attempts: int = 1) -> None:
         """Connect all instrument managers in the pool.

--- a/python/src/pypalmsens/_instruments/instrument_pool_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool_async.py
@@ -58,6 +58,12 @@ class InstrumentPoolAsync:
     def __iter__(self):
         yield from self.managers
 
+    def __contains__(self, obj: Any):
+        return obj in self.managers
+
+    def __getitem__(self, index: int) -> InstrumentManagerAsync:
+        return self.managers[index]
+
     async def connect(self, attempts: int = 1) -> None:
         """Connect all instrument managers in the pool.
 

--- a/python/tests/test_multichannel.py
+++ b/python/tests/test_multichannel.py
@@ -37,11 +37,11 @@ def test_pool(pool):
     n = len(pool.managers)
 
     assert pool.managers
-    manager = pool.managers[0]
+    manager = pool[0]
 
     pool.remove(manager)
 
-    assert manager not in pool.managers
+    assert manager not in pool
 
     pool.add(manager)
     assert len(pool.managers) == n
@@ -56,11 +56,11 @@ async def test_pool_async(apool):
     n = len(apool.managers)
 
     assert apool.managers
-    manager = apool.managers[0]
+    manager = apool[0]
 
     await apool.remove(manager)
 
-    assert manager not in apool.managers
+    assert manager not in apool
 
     await apool.add(manager)
     assert len(apool.managers) == n


### PR DESCRIPTION
This PR adds convenience magic methods to the pool class.

This enables:

```python
import pypalmsens as ps
pool = ps.InstrumentPool(ps.discover())

manager = pool[2]  # getitem
assert manager in pool  # contains
```