### PR TITLE
Add `status()` method for `IntrumentPool`

### DIFF
--- a/python/src/pypalmsens/_data/curve.py
+++ b/python/src/pypalmsens/_data/curve.py
@@ -29,7 +29,7 @@ class Curve:
 
     @override
     def __repr__(self):
-        return f'{self.__class__.__name__}(title={self.title}, n_points={self.n_points})'
+        return f'{type(self).__name__}(title={self.title}, n_points={self.n_points})'
 
     def copy(self) -> Curve:
         """Return a copy of this curve."""

--- a/python/src/pypalmsens/_data/data_array.py
+++ b/python/src/pypalmsens/_data/data_array.py
@@ -44,10 +44,7 @@ class DataArray(Sequence[float]):
     @override
     def __repr__(self):
         return (
-            f'{self.__class__.__name__}('
-            f'name={self.name}, '
-            f'unit={self.unit}, '
-            f'n_points={len(self)})'
+            f'{type(self).__name__}(name={self.name}, unit={self.unit}, n_points={len(self)})'
         )
 
     @overload

--- a/python/src/pypalmsens/_data/dataset.py
+++ b/python/src/pypalmsens/_data/dataset.py
@@ -82,7 +82,7 @@ class DataSet(Mapping[str, DataArray]):
 
     @override
     def __repr__(self):
-        return f'{self.__class__.__name__}({list(self.keys())})'
+        return f'{type(self).__name__}({list(self.keys())})'
 
     @override
     def __getitem__(self, key: str):

--- a/python/src/pypalmsens/_data/eisdata.py
+++ b/python/src/pypalmsens/_data/eisdata.py
@@ -37,7 +37,7 @@ class EISData:
             data.append(f'n_subscans={self.n_subscans}')
 
         s = ', '.join(data)
-        return f'{self.__class__.__name__}({s})'
+        return f'{type(self).__name__}({s})'
 
     @property
     def title(self) -> str:

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -58,7 +58,7 @@ class Measurement:
 
     @override
     def __repr__(self):
-        return f'{self.__class__.__name__}(title={self.title}, timestamp={self.timestamp}, device={self.device.type})'
+        return f'{type(self).__name__}(title={self.title}, timestamp={self.timestamp}, device={self.device.type})'
 
     @property
     def title(self) -> str:

--- a/python/src/pypalmsens/_data/method.py
+++ b/python/src/pypalmsens/_data/method.py
@@ -15,7 +15,7 @@ class Method:
         self._psmethod = psmethod
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}(name={self.name!r}, id={self.id!r})'
+        return f'{type(self).__name__}(name={self.name!r}, id={self.id!r})'
 
     @property
     def id(self) -> str:

--- a/python/src/pypalmsens/_data/peak.py
+++ b/python/src/pypalmsens/_data/peak.py
@@ -31,7 +31,7 @@ class Peak:
         y_unit = self.y_unit
 
         return (
-            f'{self.__class__.__name__}('
+            f'{type(self).__name__}('
             f'x={self.x:g} {x_unit}, '
             f'y={self.y:g} {y_unit}, '
             f'y_offset={self.y_offset:g} {y_unit}, '

--- a/python/src/pypalmsens/_instruments/callback.py
+++ b/python/src/pypalmsens/_instruments/callback.py
@@ -8,6 +8,8 @@ import PalmSens
 from PalmSens.Comm import StatusEventArgs
 from typing_extensions import override
 
+from pypalmsens._converters import single_to_double
+
 from .._types import AllowedDeviceState
 from ..data import CurrentReading, DataArray, DataSet, PotentialReading
 
@@ -128,6 +130,14 @@ class Status:
             {'current': str(self.current_reading), 'potential': str(self.potential_reading)}
         )
 
+    @override
+    def __repr__(self):
+        return (
+            f'{type(self).__name__}('
+            f'device_state={self.device_state!r}, '
+            f'potential={self.potential})'
+        )
+
     @property
     def pretreatment_phase(
         self,
@@ -138,7 +148,7 @@ class Status:
     @property
     def potential(self) -> float:
         """Potential in V"""
-        return self._status.PotentialReading.Value
+        return single_to_double(self._status.PotentialReading.Value)
 
     @property
     def potential_reading(self) -> PotentialReading:
@@ -148,7 +158,7 @@ class Status:
     @property
     def current(self) -> float:
         """Current value in µA."""
-        return self._status.CurrentReading.Value
+        return single_to_double(self._status.CurrentReading.Value)
 
     @property
     def current_reading(self) -> CurrentReading:
@@ -158,7 +168,7 @@ class Status:
     @property
     def current_we2(self) -> float:
         """Current WE2 value."""
-        return self._status.CurrentReadingWE2.Value
+        return single_to_double(self._status.CurrentReadingWE2.Value)
 
     @property
     def current_reading_we2(self) -> CurrentReading:
@@ -168,22 +178,22 @@ class Status:
     @property
     def aux_input(self) -> float:
         """Raw aux input."""
-        return self._status.AuxInput
+        return single_to_double(self._status.AuxInput)
 
     @property
     def aux_input_as_voltage(self) -> float:
         """Aux input as V."""
-        return self._status.GetAuxInputAsVoltage()
+        return single_to_double(self._status.GetAuxInputAsVoltage())
 
     @property
     def corrected_bipot_current(self) -> float:
         """Corrected bipot current in the current range."""
-        return self._status.GetCorrectedBipotCurrent()
+        return single_to_double(self._status.GetCorrectedBipotCurrent())
 
     @property
     def noise(self) -> float:
         """Measured"""
-        return self._status.Noise
+        return single_to_double(self._status.Noise)
 
 
 class CallbackStatus(Protocol):

--- a/python/src/pypalmsens/_instruments/instrument.py
+++ b/python/src/pypalmsens/_instruments/instrument.py
@@ -139,7 +139,7 @@ class Instrument:
             )
         )
 
-        return f'{self.__class__.__name__}({args})'
+        return f'{type(self).__name__}({args})'
 
     @property
     def baudrate(self) -> int:

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -121,9 +121,7 @@ class InstrumentManager(CapabilitiesMixin):
 
     @override
     def __repr__(self):
-        return (
-            f'{self.__class__.__name__}({self.instrument.id}, connected={self.is_connected()})'
-        )
+        return f'{type(self).__name__}({self.instrument.id}, connected={self.is_connected()})'
 
     def __enter__(self):
         if not self.is_connected():
@@ -182,6 +180,7 @@ class InstrumentManager(CapabilitiesMixin):
 
     def status(self) -> Status:
         """Get status."""
+        self.ensure_connection()
         return Status(
             self._comm.get_Status(),
             device_state=str(self._comm.get_State()),  # type:ignore

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -257,9 +257,7 @@ class InstrumentManagerAsync(CapabilitiesMixin):
 
     @override
     def __repr__(self):
-        return (
-            f'{self.__class__.__name__}({self.instrument.id}, connected={self.is_connected()})'
-        )
+        return f'{type(self).__name__}({self.instrument.id}, connected={self.is_connected()})'
 
     async def __aenter__(self):
         if not self.is_connected():
@@ -314,6 +312,7 @@ class InstrumentManagerAsync(CapabilitiesMixin):
 
     def status(self) -> Status:
         """Get status."""
+        self.ensure_connection()
         return Status(
             self._comm.get_Status(),
             device_state=str(self._comm.get_State()),  # type:ignore

--- a/python/src/pypalmsens/_instruments/instrument_pool.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool.py
@@ -39,7 +39,7 @@ class InstrumentPool:
 
     def __repr__(self):
         ids = [manager.instrument.id for manager in self.managers]
-        return f'{self.__class__.__name__}({ids}, connected={self.is_connected()})'
+        return f'{type(self).__name__}({ids}, connected={self.is_connected()})'
 
     def __len__(self):
         return len(self.managers)

--- a/python/src/pypalmsens/_instruments/instrument_pool.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Sequence
 
 from .._methods import BaseTechnique
-from .callback import Callback, CallbackEIS
+from .callback import Callback, CallbackEIS, Status
 from .instrument import Instrument
 from .instrument_manager_async import InstrumentManagerAsync
 from .instrument_pool_async import InstrumentPoolAsync
@@ -102,6 +102,16 @@ class InstrumentPool:
             Instance of an instrument manager.
         """
         self._loop.run_until_complete(self._async.add(manager))
+
+    def status(self) -> list[Status]:
+        """Return status for all managers in pool.
+
+        Returns
+        -------
+        list[Status]
+            List of status objects.
+        """
+        return [manager.status() for manager in self]
 
     def measure(
         self,

--- a/python/src/pypalmsens/_instruments/instrument_pool_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool_async.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any, Awaitable, Protocol, Sequence
 
 from .._methods import BaseTechnique
-from .callback import Callback, CallbackEIS
+from .callback import Callback, CallbackEIS, Status
 from .instrument import Instrument
 from .instrument_manager_async import InstrumentManagerAsync
 
@@ -120,6 +120,16 @@ class InstrumentPoolAsync:
         """
         await manager.connect()
         self.managers.append(manager)
+
+    def status(self) -> list[Status]:
+        """Return status for all managers in pool.
+
+        Returns
+        -------
+        list[Status]
+            List of status objects.
+        """
+        return [manager.status() for manager in self]
 
     async def measure(
         self,

--- a/python/src/pypalmsens/_instruments/instrument_pool_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool_async.py
@@ -43,7 +43,7 @@ class InstrumentPoolAsync:
 
     def __repr__(self):
         ids = [manager.instrument.id for manager in self.managers]
-        return f'{self.__class__.__name__}({ids}, connected={self.is_connected()})'
+        return f'{type(self).__name__}({ids}, connected={self.is_connected()})'
 
     def __len__(self):
         return len(self.managers)

--- a/python/tests/test_multichannel.py
+++ b/python/tests/test_multichannel.py
@@ -47,6 +47,8 @@ def test_pool(pool):
     assert len(pool.managers) == n
     assert manager in pool.managers
 
+    assert len(pool.status()) == len(pool)
+
 
 @pytest.mark.asyncio
 @pytest.mark.instrument
@@ -65,6 +67,8 @@ async def test_pool_async(apool):
     await apool.add(manager)
     assert len(apool.managers) == n
     assert manager in apool.managers
+
+    assert len(pool.status()) == len(apool)
 
 
 @pytest.mark.instrument


### PR DESCRIPTION
This PR adds a `status()` method to the InstrumentPool. This makes it convenient to see the state of all devices in a single glance. It also updates some repr methods.

```python
>>> import pypalmsens as ps

>>> with ps.InstrumentPool(ps.discover()) as pool:
...     print(pool.status())
[Status(device_state='Idle', potential=0.360944),
 Status(device_state='Idle', potential=0.326801),
 Status(device_state='Idle', potential=0.394401),
 Status(device_state='Idle', potential=0.474722),
 Status(device_state='Idle', potential=0.461801),
 Status(device_state='Idle', potential=0.316263),
 Status(device_state='Idle', potential=0.396988),
 Status(device_state='Idle', potential=0.441131),
 Status(device_state='Idle', potential=0.315637),
 Status(device_state='Idle', potential=0.370272),
 Status(device_state='Idle', potential=0.433643),
 Status(device_state='Idle', potential=0.431020)]
```