### PR TITLE
Add support for cell on

### DIFF
--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -197,6 +197,17 @@ class InstrumentManager(CapabilitiesMixin):
         with self._lock():
             self._comm.CellOn = cell_on
 
+    def is_cell_on(self) -> bool:
+        """Get cell status.
+
+        Returns
+        -------
+        cell_on : bool
+            Return true if the cell is on
+        """
+        with self._lock():
+            return self._comm.CellOn
+
     def read_current(self) -> float:
         """Read the current in µA.
 

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -329,6 +329,19 @@ class InstrumentManagerAsync(CapabilitiesMixin):
         async with self._lock():
             await create_future(self._comm.SetCellOnAsync(cell_on))
 
+    async def is_cell_on(self) -> bool:
+        """Get cell status.
+
+        Returns
+        -------
+        cell_on : bool
+            Return true if the cell is on
+        """
+        async with self._lock():
+            cell_on: bool = await create_future(self._comm.GetCellOnAsync())
+
+        return cell_on
+
     async def read_current(self) -> float:
         """Read the current in µA.
 

--- a/python/tests/test_multichannel.py
+++ b/python/tests/test_multichannel.py
@@ -68,7 +68,7 @@ async def test_pool_async(apool):
     assert len(apool.managers) == n
     assert manager in apool.managers
 
-    assert len(pool.status()) == len(apool)
+    assert len(apool.status()) == len(apool)
 
 
 @pytest.mark.instrument

--- a/python/tests/test_techniques.py
+++ b/python/tests/test_techniques.py
@@ -37,8 +37,19 @@ def test_status(manager):
 
 
 @pytest.mark.instrument
-def test_read_current(manager):
+def test_cell_on(manager):
+    assert not manager.is_cell_on()
     manager.set_cell(True)
+    assert manager.is_cell_on()
+    manager.set_cell(False)
+    assert not manager.is_cell_on()
+
+
+@pytest.mark.instrument
+def test_read_current(manager):
+    assert not manager.is_cell_on()
+    manager.set_cell(True)
+    assert manager.is_cell_on()
 
     manager.set_current_range('1uA')
     val1 = manager.read_current()
@@ -53,6 +64,7 @@ def test_read_current(manager):
     assert cr2 == '10uA'
 
     manager.set_cell(False)
+    assert not manager.is_cell_on()
 
 
 @pytest.mark.instrument

--- a/python/tests/test_techniques_async.py
+++ b/python/tests/test_techniques_async.py
@@ -37,6 +37,16 @@ def test_status_async(manager):
 
 @pytest.mark.instrument
 @pytest.mark.asyncio
+async def test_cell_on(manager):
+    assert not await manager.is_cell_on()
+    await manager.set_cell(True)
+    assert await manager.is_cell_on()
+    await manager.set_cell(False)
+    assert not await manager.is_cell_on()
+
+
+@pytest.mark.instrument
+@pytest.mark.asyncio
 async def test_read_current(manager):
     await manager.set_cell(True)
 


### PR DESCRIPTION
This PR adds a method to the instrument manager to see if the cell is on:

```python
>>> import pypalmsens as ps
>>> with ps.connect() as manager:
...     print(manager.is_cell_on())
...     manager.set_cell(True)
...     print(manager.is_cell_on())
False
True
```