### PR TITLE
Raise Attribute error for module __getattr__

### DIFF
--- a/python/src/pypalmsens/settings.py
+++ b/python/src/pypalmsens/settings.py
@@ -48,7 +48,7 @@ def __getattr__(name: str) -> Any:
         from . import types
 
         return getattr(types, name)
-    return globals()[name]
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 
 
 __all__ = [


### PR DESCRIPTION
This PR raises AttributeError for `__getattr__` for the deprecated functions/classes, instead of attempting to get the value from globals, which incorrectly raises KeyError on fail.