### PR TITLE
Add method to serialize method parameters

### DIFF
--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -120,7 +119,7 @@ def load_method_file(path: str | Path, as_method: bool = False) -> BaseTechnique
         return method.to_settings()
 
 
-def save_method_file(path: str | Path, method: Method | BaseTechnique):
+def save_method_file(path: str | Path, method: BaseTechnique):
     """Load a method file (.psmethod).
 
     Parameters
@@ -130,29 +129,7 @@ def save_method_file(path: str | Path, method: Method | BaseTechnique):
     method : Method
         Method to save
     """
-    from . import __sdk_version__
+    data = method._serialize()
 
-    if isinstance(method, BaseTechnique):
-        psmethod = method._to_psmethod()
-    elif isinstance(method, Method):
-        psmethod = method._psmethod
-    else:
-        raise ValueError(f'Unknown data type: {type(method)}')
-
-    path = Path(path)
-
-    with stream_writer(str(path), False, Encoding.Unicode) as stream:
-        PalmSens.DataFiles.MethodFile2.Save(
-            psmethod, stream.BaseStream, str(path), True, __sdk_version__
-        )
-
-
-def read_notes(path: str | Path, n_chars: int = 3000):
-    with open(path, encoding='utf16') as myfile:
-        contents = myfile.read()
-    raw_txt = contents[1:n_chars].split('\\r\\n')
-    notes_list = [x for x in raw_txt if 'NOTES=' in x]
-    notes_txt = (
-        notes_list[0].replace('%20', ' ').replace('NOTES=', '').replace('%crlf', os.linesep)
-    )
-    return notes_txt
+    with open(path, 'w') as f:
+        _ = f.write(data)

--- a/python/src/pypalmsens/_methods/base.py
+++ b/python/src/pypalmsens/_methods/base.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from contextlib import contextmanager
 from typing import Any, ClassVar
 
 import PalmSens
+from System.IO import StringWriter
 
+from .. import __version__
 from .base_model import BaseModel
+
+
+@contextmanager
+def string_writer(*args, **kwargs):
+    stream = StringWriter(*args, **kwargs)
+    try:
+        yield stream
+    finally:
+        stream.Close()
 
 
 class BaseSettings(BaseModel, metaclass=ABCMeta):
@@ -44,6 +56,15 @@ class BaseTechnique(BaseModel, metaclass=ABCMeta):
         """Create new instance of appropriate technique from method ID."""
         new = cls._registry[id]
         return new()
+
+    def _serialize(self) -> str:
+        """Serialize to string that can be written to pssession file."""
+        psmethod = self._to_psmethod()
+        with string_writer() as stream:
+            PalmSens.DataFiles.MethodFile2.Serialize(
+                psmethod, stream, 'PyPalmSens', __version__
+            )
+            return str(stream)
 
     @classmethod
     def _from_psmethod(cls, psmethod: PalmSens.Method, /) -> BaseTechnique:

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -53,3 +53,10 @@ def test_save_load_method(tmpdir):
             assert v2 == approx(v)
         else:
             assert v == v2
+
+
+def test_serialize():
+    cv = ps.CyclicVoltammetry()
+    s = cv._serialize()
+
+    assert s.startswith('#PyPalmSens,')


### PR DESCRIPTION
This refactors `ps.save_method_file` so that the method parameters can be serialized to a text stream.