### PR TITLE
Add literal scan/frequency types

### DIFF
--- a/python/docs/zensical/data.md
+++ b/python/docs/zensical/data.md
@@ -426,9 +426,9 @@ The EISData object can be queried for metadata:
 >>> eis.title
 'FixedPotential at 71 freqs [2]'
 >>> eis.scan_type
-'Fixed'
+'fixed'
 >>> eis.frequency_type
-'Scan'
+'scan'
 >>> eis.n_points
 5
 >>> eis.n_frequencies

--- a/python/src/pypalmsens/_data/eisdata.py
+++ b/python/src/pypalmsens/_data/eisdata.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, final
 from typing_extensions import override
 
 from .._converters import cr_enum_to_string
-from .._types import AllowedCurrentRanges
+from .._types import AllowedCurrentRanges, AllowedFrequencyTypes, AllowedScanTypes
 from .data_array import DataArray
 from .dataset import DataSet
 
@@ -45,14 +45,16 @@ class EISData:
         return self._pseis.Title
 
     @property
-    def frequency_type(self) -> str:
+    def frequency_type(self) -> AllowedFrequencyTypes:
         """Frequency type."""
-        return str(self._pseis.FreqType)
+        return str(self._pseis.FreqType).lower()  # type: ignore
 
     @property
-    def scan_type(self) -> str:
+    def scan_type(self) -> AllowedScanTypes:
         """Scan type."""
-        return str(self._pseis.ScanType)
+        value = str(self._pseis.ScanType)
+        mapping = {'TimeScan': 'time', 'PGScan': 'potential', 'Fixed': 'fixed'}
+        return mapping[value]  # type: ignore
 
     @property
     def dataset(self) -> DataSet:

--- a/python/src/pypalmsens/_fitting.py
+++ b/python/src/pypalmsens/_fitting.py
@@ -444,11 +444,11 @@ class CircuitModel:
         result : FitResult
             Returns dataclass with fit results. Can also be accessed via `.last_result`.
         """
-        if not data.frequency_type == 'Scan':
+        if not data.frequency_type == 'scan':
             raise ValueError(
                 f'Fit only supports EIS scans at a fixed potential, got {data.frequency_type=}.'
             )
-        if not data.scan_type == 'Fixed':
+        if not data.scan_type == 'fixed':
             raise ValueError(
                 f'Fit only supports EIS scans at a fixed potential, got {data.scan_type=}.'
             )

--- a/python/src/pypalmsens/_methods/techniques.py
+++ b/python/src/pypalmsens/_methods/techniques.py
@@ -19,7 +19,9 @@ from .._converters import (
 )
 from .._types import (
     AllowedCurrentRanges,
+    AllowedFrequencyTypes,
     AllowedPotentialRanges,
+    AllowedScanTypes,
 )
 from . import mixins
 from .base import BaseTechnique
@@ -1728,12 +1730,12 @@ class ElectrochemicalImpedanceSpectroscopy(
     id: Literal['eis'] = 'eis'
     """Unique method identifier."""
 
-    _SCAN_TYPES: tuple[Literal['potential', 'time', 'fixed'], ...] = (
+    _SCAN_TYPES: tuple[AllowedScanTypes, ...] = (
         'potential',
         'time',
         'fixed',
     )
-    _FREQ_TYPES: tuple[Literal['fixed', 'scan'], ...] = ('fixed', 'scan')
+    _FREQ_TYPES: tuple[AllowedFrequencyTypes, ...] = ('fixed', 'scan')
 
     equilibration_time: float = 0.0
     """Equilibration time in s."""
@@ -1751,7 +1753,7 @@ class ElectrochemicalImpedanceSpectroscopy(
     (RMS). In many applications, a value of 0.010 V (RMS) is used.
     """
 
-    frequency_type: Literal['fixed', 'scan'] = 'scan'
+    frequency_type: AllowedFrequencyTypes = 'scan'
     """Whether to measure a single frequency or scan over a range of frequencies.
 
     Possible values: 'scan', 'fixed'.
@@ -1779,7 +1781,7 @@ class ElectrochemicalImpedanceSpectroscopy(
     including both end points.
     """
 
-    scan_type: Literal['potential', 'time', 'fixed'] = 'fixed'
+    scan_type: AllowedScanTypes = 'fixed'
     """Whether a single or multiple frequency scans are performed.
 
     Possible values: 'potential', 'time', 'fixed'.

--- a/python/src/pypalmsens/_types.py
+++ b/python/src/pypalmsens/_types.py
@@ -98,3 +98,10 @@ AllowedPotentialRanges = Literal[
 
 See the device documentation or query the instrument manager
 for supported potential ranges."""
+
+
+AllowedScanTypes = Literal['potential', 'time', 'fixed']
+"""Possible scan types."""
+
+AllowedFrequencyTypes = Literal['fixed', 'scan']
+"""Possibl frequency types."""

--- a/python/src/pypalmsens/types.py
+++ b/python/src/pypalmsens/types.py
@@ -6,9 +6,11 @@ from ._data.types import AllowedArrayTypes
 from ._types import (
     AllowedCurrentRanges,
     AllowedDeviceState,
+    AllowedFrequencyTypes,
     AllowedMethods,
     AllowedPotentialRanges,
     AllowedReadingStatus,
+    AllowedScanTypes,
     AllowedTimingStatus,
 )
 
@@ -16,8 +18,10 @@ __all__ = [
     'AllowedArrayTypes',
     'AllowedCurrentRanges',
     'AllowedDeviceState',
+    'AllowedFrequencyTypes',
     'AllowedMethods',
     'AllowedPotentialRanges',
     'AllowedReadingStatus',
+    'AllowedScanTypes',
     'AllowedTimingStatus',
 ]

--- a/python/tests/test_eis_data.py
+++ b/python/tests/test_eis_data.py
@@ -22,8 +22,8 @@ def test_eis_data(eis_simple):
     assert not eis.has_subscans
     assert eis.n_subscans == 0
 
-    assert eis.scan_type == 'Fixed'
-    assert eis.frequency_type == 'Scan'
+    assert eis.scan_type == 'fixed'
+    assert eis.frequency_type == 'scan'
     assert eis.n_points == 5
     assert eis.n_frequencies == 5
 
@@ -55,8 +55,8 @@ def test_eis_data_mux_subscans(eis_mux_subscans):
     assert eis.has_subscans
     assert eis.n_subscans == 4
 
-    assert eis.scan_type == 'PGScan'
-    assert eis.frequency_type == 'Scan'
+    assert eis.scan_type == 'potential'
+    assert eis.frequency_type == 'scan'
     assert eis.n_points == 20
     assert eis.n_frequencies == 5
 


### PR DESCRIPTION
This PR adds `AllowedFrequencyTypes` and `AllowedScanTypes` to the `pypalmsens.types` module.