### PR TITLE
Update types and type checking

### DIFF
--- a/python/examples/load_save_data.py
+++ b/python/examples/load_save_data.py
@@ -1,12 +1,13 @@
-from pathlib import Path
+from __future__ import annotations
 
+from pathlib import Path
 
 import pypalmsens as ps
 
 examples_dir = Path(__file__).parent
 
 # load a method file
-method = ps.load_method_file(examples_dir / 'PSDummyCell_LSV.psmethod', as_method=True)
+method = ps.load_method_file(examples_dir / 'PSDummyCell_LSV.psmethod')
 
 # save the method file
 ps.save_method_file(examples_dir / 'PSDummyCell_LSV_copy.psmethod', method)

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -7,7 +7,7 @@ import System
 from typing_extensions import override
 
 from .._fitting import FitResult
-from .._types import TechniqueTypeCompatible
+from .._types import MethodTypeCompatible
 from .curve import Curve
 from .dataset import DataSet
 from .eisdata import EISData
@@ -114,7 +114,7 @@ class Measurement:
         return lst
 
     @property
-    def method(self) -> TechniqueTypeCompatible:
+    def method(self) -> MethodTypeCompatible:
         """Method related with this Measurement.
 
         The information from the Method is used when saving Curves."""

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -6,9 +6,8 @@ from typing import TYPE_CHECKING, final
 import System
 from typing_extensions import override
 
-from pypalmsens._methods import BaseTechnique
-
 from .._fitting import FitResult
+from .._types import TechniqueTypeCompatible
 from .curve import Curve
 from .dataset import DataSet
 from .eisdata import EISData
@@ -115,7 +114,7 @@ class Measurement:
         return lst
 
     @property
-    def method(self) -> BaseTechnique:
+    def method(self) -> TechniqueTypeCompatible:
         """Method related with this Measurement.
 
         The information from the Method is used when saving Curves."""

--- a/python/src/pypalmsens/_data/method.py
+++ b/python/src/pypalmsens/_data/method.py
@@ -5,6 +5,8 @@ from typing import Any, Union
 
 import PalmSens
 
+from pypalmsens.types import TechniqueType
+
 from .._methods.techniques import BaseTechnique
 
 
@@ -50,10 +52,10 @@ class Method:
         """The technique number used in the firmware."""
         return self._psmethod.Technique
 
-    def to_settings(self) -> BaseTechnique:
+    def to_settings(self) -> TechniqueType:
         """Extract techniques parameters as dataclass."""
         return BaseTechnique._from_psmethod(self._psmethod)
 
     def to_dict(self) -> dict[str, Any]:
         """Return dictionary with technique parameters."""
-        return self.to_settings().model_dump()
+        return self.to_settings().to_dict()

--- a/python/src/pypalmsens/_data/method.py
+++ b/python/src/pypalmsens/_data/method.py
@@ -5,7 +5,7 @@ from typing import Any, Union
 
 import PalmSens
 
-from pypalmsens.types import TechniqueType
+from pypalmsens.types import MethodType
 
 from .._methods.techniques import BaseTechnique
 
@@ -52,7 +52,7 @@ class Method:
         """The technique number used in the firmware."""
         return self._psmethod.Technique
 
-    def to_settings(self) -> TechniqueType:
+    def to_settings(self) -> MethodType:
         """Extract techniques parameters as dataclass."""
         return BaseTechnique._from_psmethod(self._psmethod)
 

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -20,7 +20,7 @@ from .._converters import (
 from .._types import (
     AllowedCurrentRanges,
     AllowedPotentialRanges,
-    TechniqueTypeCompatible,
+    MethodTypeCompatible,
 )
 from ..data import Measurement
 from .callback import Callback, CallbackEIS, Status
@@ -68,7 +68,7 @@ def connect(
 
 
 def measure(
-    method: TechniqueTypeCompatible,
+    method: MethodTypeCompatible,
     instrument: None | Instrument = None,
     callback: Callback | CallbackEIS | None = None,
 ) -> Measurement:
@@ -303,7 +303,7 @@ class InstrumentManager(CapabilitiesMixin):
 
     def measure(
         self,
-        method: TechniqueTypeCompatible,
+        method: MethodTypeCompatible,
         *,
         callback: Callback | CallbackEIS | None = None,
     ) -> Measurement:

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -311,7 +311,7 @@ class InstrumentManager(CapabilitiesMixin):
 
         Parameters
         ----------
-        method: TechniqueType
+        method: MethodType
             Method parameters for measurement
         callback: Callback, optional
             If specified, call this function on every new set of data points.

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -19,12 +19,10 @@ from .._converters import (
     pr_enum_to_string,
     pr_string_to_enum,
 )
-from .._methods import (
-    BaseTechnique,
-)
 from .._types import (
     AllowedCurrentRanges,
     AllowedPotentialRanges,
+    TechniqueTypeCompatible,
 )
 from ..data import Measurement
 from .callback import Callback, CallbackEIS, Status
@@ -72,7 +70,7 @@ def connect(
 
 
 def measure(
-    method: BaseTechnique,
+    method: TechniqueTypeCompatible,
     instrument: None | Instrument = None,
     callback: Callback | CallbackEIS | None = None,
 ) -> Measurement:

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -4,14 +4,12 @@ import asyncio
 import warnings
 from contextlib import contextmanager
 from time import sleep
-from typing import Iterator
+from typing import Generator
 
 import clr
 import PalmSens
 from PalmSens.Comm import CommManager, MuxType
 from typing_extensions import override
-
-from pypalmsens._methods.adapters import EnergyTechniqueType, TechniqueType
 
 from .._converters import (
     cr_enum_to_string,
@@ -136,7 +134,7 @@ class InstrumentManager(CapabilitiesMixin):
         return int(self._comm.State) == CommManager.DeviceState.Measurement
 
     @contextmanager
-    def _lock(self) -> Iterator[CommManager]:
+    def _lock(self) -> Generator[CommManager]:
         self.ensure_connection()
 
         self._comm.ClientConnection.Semaphore.Wait()
@@ -305,7 +303,7 @@ class InstrumentManager(CapabilitiesMixin):
 
     def measure(
         self,
-        method: TechniqueType | EnergyTechniqueType,
+        method: TechniqueTypeCompatible,
         *,
         callback: Callback | CallbackEIS | None = None,
     ) -> Measurement:
@@ -328,7 +326,7 @@ class InstrumentManager(CapabilitiesMixin):
             Finished measurement.
         """
         self.ensure_connection()
-        self.validate_method(method)  # type: ignore
+        self.validate_method(method)
 
         # note that the comm manager must be opened async so it sets the
         # correct async event handlers

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -24,7 +24,7 @@ from .._types import (
     AllowedCurrentRanges,
     AllowedMethods,
     AllowedPotentialRanges,
-    TechniqueTypeCompatible,
+    MethodTypeCompatible,
 )
 from ..data import Measurement
 from .callback import Callback, CallbackEIS, CallbackStatus, Status
@@ -76,7 +76,7 @@ async def connect_async(
 
 
 async def measure_async(
-    method: TechniqueTypeCompatible,
+    method: MethodTypeCompatible,
     instrument: None | Instrument = None,
     callback: Callback | CallbackEIS | None = None,
 ) -> Measurement:
@@ -190,7 +190,7 @@ class CapabilitiesMixin:
 
     def get_estimated_duration(
         self: HasCommProtocol,
-        method: PalmSens.Method | TechniqueTypeCompatible,
+        method: PalmSens.Method | MethodTypeCompatible,
     ) -> float:
         """Get the estimated duration for this method.
 
@@ -215,7 +215,7 @@ class CapabilitiesMixin:
 
     def validate_method(
         self: HasCommProtocol,
-        method: TechniqueTypeCompatible,
+        method: MethodTypeCompatible,
     ):
         """Validate method.
 
@@ -482,7 +482,7 @@ class InstrumentManagerAsync(CapabilitiesMixin):
 
     async def measure(
         self,
-        method: TechniqueTypeCompatible,
+        method: MethodTypeCompatible,
         *,
         callback: Callback | CallbackEIS | None = None,
         sync_event: asyncio.Event | None = None,

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -196,7 +196,7 @@ class CapabilitiesMixin:
 
         Parameters
         -----------
-        method : Method parameters
+        method : MethodType
             The method to get the estimated duration for.
 
         Returns
@@ -223,7 +223,7 @@ class CapabilitiesMixin:
 
         Parameters
         -----------
-        method: TechniqueType
+        method: MethodType
             The method to validate.
         """
         self.ensure_connection()
@@ -491,7 +491,7 @@ class InstrumentManagerAsync(CapabilitiesMixin):
 
         Parameters
         ----------
-        method: MethodParameters
+        method: MethodType
             Method parameters for measurement
         callback: Callback, optional
             If specified, call this function on every new set of data points.

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -13,19 +13,17 @@ from PalmSens.Comm import CommManager, MuxType
 from System.Threading.Tasks import Task
 from typing_extensions import AsyncIterator, override
 
-from pypalmsens._methods.adapters import EnergyTechniqueType, TechniqueType
-
 from .._converters import (
     cr_enum_to_string,
     cr_string_to_enum,
     pr_enum_to_string,
     pr_string_to_enum,
 )
-from .._methods import BaseTechnique
 from .._types import (
     AllowedCurrentRanges,
     AllowedMethods,
     AllowedPotentialRanges,
+    TechniqueTypeCompatible,
 )
 from ..data import Measurement
 from .callback import Callback, CallbackEIS, CallbackStatus, Status
@@ -77,7 +75,7 @@ async def connect_async(
 
 
 async def measure_async(
-    method: BaseTechnique,
+    method: TechniqueTypeCompatible,
     instrument: None | Instrument = None,
     callback: Callback | CallbackEIS | None = None,
 ) -> Measurement:
@@ -190,7 +188,7 @@ class CapabilitiesMixin:
 
     def get_estimated_duration(
         self: HasCommProtocol,
-        method: PalmSens.Method | BaseTechnique,
+        method: PalmSens.Method | TechniqueTypeCompatible,
     ) -> float:
         """Get the estimated duration for this method.
 
@@ -215,7 +213,7 @@ class CapabilitiesMixin:
 
     def validate_method(
         self: HasCommProtocol,
-        method: TechniqueType | EnergyTechniqueType,
+        method: TechniqueTypeCompatible,
     ):
         """Validate method.
 
@@ -482,7 +480,7 @@ class InstrumentManagerAsync(CapabilitiesMixin):
 
     async def measure(
         self,
-        method: TechniqueType,
+        method: TechniqueTypeCompatible,
         *,
         callback: Callback | CallbackEIS | None = None,
         sync_event: asyncio.Event | None = None,

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import asyncio
 import sys
 import warnings
+from collections.abc import AsyncGenerator, Coroutine
 from contextlib import asynccontextmanager
-from typing import Any, Callable, Coroutine, Protocol
+from typing import Any, Protocol
 
 import clr
 import PalmSens
 from PalmSens import AsyncEventHandler
 from PalmSens.Comm import CommManager, MuxType
 from System.Threading.Tasks import Task
-from typing_extensions import AsyncIterator, override
+from typing_extensions import override
 
 from .._converters import (
     cr_enum_to_string,
@@ -111,7 +112,8 @@ async def measure_async(
 
 class HasCommProtocol(Protocol):
     _comm: CommManager
-    ensure_connection: Callable[[], None]
+
+    def ensure_connection(self) -> None: ...
 
 
 class HasCapabilities(Protocol):
@@ -270,7 +272,7 @@ class InstrumentManagerAsync(CapabilitiesMixin):
         return int(self._comm.State) == CommManager.DeviceState.Measurement
 
     @asynccontextmanager
-    async def _lock(self) -> AsyncIterator[CommManager]:
+    async def _lock(self) -> AsyncGenerator[CommManager]:
         self.ensure_connection()
 
         await create_future(self._comm.ClientConnection.Semaphore.WaitAsync())

--- a/python/src/pypalmsens/_instruments/instrument_pool.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool.py
@@ -134,7 +134,7 @@ class InstrumentPool:
 
         Parameters
         ----------
-        method : MethodSettings
+        method : MethodType
             Method parameters for measurement.
         callback : list[Callback] | Callback | CallbackEIS | None
             If specified, call these functions/this function on every new set of data points.

--- a/python/src/pypalmsens/_instruments/instrument_pool.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Sequence
 
-from .._methods import BaseTechnique
+from .._types import TechniqueType
 from .callback import Callback, CallbackEIS, Status
 from .instrument import Instrument
 from .instrument_manager_async import InstrumentManagerAsync
@@ -115,7 +115,7 @@ class InstrumentPool:
 
     def measure(
         self,
-        method: BaseTechnique,
+        method: TechniqueType,
         callback: Sequence[Callback | CallbackEIS] | Callback | CallbackEIS | None = None,
         **kwargs,
     ) -> list[Measurement]:

--- a/python/src/pypalmsens/_instruments/instrument_pool.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Sequence
 
-from .._types import TechniqueType
+from .._types import MethodType
 from .callback import Callback, CallbackEIS, Status
 from .instrument import Instrument
 from .instrument_manager_async import InstrumentManagerAsync
@@ -115,7 +115,7 @@ class InstrumentPool:
 
     def measure(
         self,
-        method: TechniqueType,
+        method: MethodType,
         callback: Sequence[Callback | CallbackEIS] | Callback | CallbackEIS | None = None,
         **kwargs,
     ) -> list[Measurement]:

--- a/python/src/pypalmsens/_instruments/instrument_pool_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool_async.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Awaitable, Protocol, Sequence
 
-from .._types import TechniqueType, TechniqueTypeCompatible
+from .._types import MethodType, MethodTypeCompatible
 from .callback import Callback, CallbackEIS, Status
 from .instrument import Instrument
 from .instrument_manager_async import InstrumentManagerAsync
@@ -133,7 +133,7 @@ class InstrumentPoolAsync:
 
     async def measure(
         self,
-        method: TechniqueType,
+        method: MethodType,
         callback: Sequence[Callback | CallbackEIS] | Callback | CallbackEIS | None = None,
         **kwargs,
     ) -> list[Measurement]:
@@ -188,7 +188,7 @@ class InstrumentPoolAsync:
 
     async def _measure_hw_sync(
         self,
-        method: TechniqueTypeCompatible,
+        method: MethodTypeCompatible,
         callbacks: Sequence[Callback | CallbackEIS | None] | None = None,
         **kwargs,
     ) -> list[Measurement]:

--- a/python/src/pypalmsens/_instruments/instrument_pool_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool_async.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, Awaitable, Protocol, Sequence
 
-from .._methods import BaseTechnique
+from .._types import TechniqueType, TechniqueTypeCompatible
 from .callback import Callback, CallbackEIS, Status
 from .instrument import Instrument
 from .instrument_manager_async import InstrumentManagerAsync
@@ -133,7 +133,7 @@ class InstrumentPoolAsync:
 
     async def measure(
         self,
-        method: BaseTechnique,
+        method: TechniqueType,
         callback: Sequence[Callback | CallbackEIS] | Callback | CallbackEIS | None = None,
         **kwargs,
     ) -> list[Measurement]:
@@ -188,7 +188,7 @@ class InstrumentPoolAsync:
 
     async def _measure_hw_sync(
         self,
-        method: BaseTechnique,
+        method: TechniqueTypeCompatible,
         callbacks: Sequence[Callback | CallbackEIS | None] | None = None,
         **kwargs,
     ) -> list[Measurement]:

--- a/python/src/pypalmsens/_instruments/instrument_pool_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_pool_async.py
@@ -152,7 +152,7 @@ class InstrumentPoolAsync:
 
         Parameters
         ----------
-        method : MethodSettings
+        method : MethodType
             Method parameters for measurement.
         callback : list[Callback] | Callback | CallbackEIS | None
             If specified, call these functions/this function on every new set of data points.
@@ -196,7 +196,7 @@ class InstrumentPoolAsync:
 
         Parameters
         ----------
-        method : MethodSettings
+        method : MethodType
             Method parameters for measurement.
         callbacks : list[Callback | CallbackEIS | None]
             List of callbacks, must match number of managers.

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -142,7 +142,7 @@ class MeasurementManagerAsync:
 
         Parameters
         ----------
-        method: TechniqueType
+        method: MethodType
             Method parameters for measurement
         callback: Callback, optional
             Gets called every time new data is added

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -10,7 +10,8 @@ from PalmSens.Comm import CommManager
 from System import EventHandler
 from System.Threading.Tasks import Task
 
-from pypalmsens._methods.adapters import EnergyTechniqueType, TechniqueType
+from pypalmsens._methods.adapters import EnergyTechniqueType
+from pypalmsens._types import TechniqueTypeCompatible
 
 from .._data import DataSet
 from ..data import DataArray, Measurement
@@ -133,7 +134,7 @@ class MeasurementManagerAsync:
 
     async def measure(
         self,
-        method: TechniqueType | EnergyTechniqueType,
+        method: TechniqueTypeCompatible,
         callback: Callback | CallbackEIS | None = None,
         sync_event: asyncio.Event | None = None,
     ) -> Measurement:

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -11,7 +11,7 @@ from System import EventHandler
 from System.Threading.Tasks import Task
 
 from pypalmsens._methods.adapters import EnergyTechniqueType
-from pypalmsens._types import TechniqueTypeCompatible
+from pypalmsens._types import MethodTypeCompatible
 
 from .._data import DataSet
 from ..data import DataArray, Measurement
@@ -134,7 +134,7 @@ class MeasurementManagerAsync:
 
     async def measure(
         self,
-        method: TechniqueTypeCompatible,
+        method: MethodTypeCompatible,
         callback: Callback | CallbackEIS | None = None,
         sync_event: asyncio.Event | None = None,
     ) -> Measurement:

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -108,12 +108,10 @@ def load_method_file(path: str | Path) -> MethodType:
     ----------
     path : Path | str
         Path to method file
-    as_method : bool
-        If True, load as method wrapper object
 
     Returns
     -------
-    method : Parameters
+    method : MethodType
         Return method parameters
     """
     method = _load_method_file(path)

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -7,14 +8,13 @@ import PalmSens
 from System.IO import StreamReader, StreamWriter
 from System.Text import Encoding
 
-from pypalmsens._types import TechniqueType, TechniqueTypeCompatible
-
 from ._data import Method
 from ._data.measurement import Measurement
+from ._types import TechniqueType, TechniqueTypeCompatible
 
 
 @contextmanager
-def stream_reader(*args, **kwargs):
+def stream_reader(*args, **kwargs) -> Generator[StreamReader]:
     sr = StreamReader(*args, **kwargs)
     try:
         yield sr
@@ -23,7 +23,7 @@ def stream_reader(*args, **kwargs):
 
 
 @contextmanager
-def stream_writer(*args, **kwargs):
+def stream_writer(*args, **kwargs) -> Generator[StreamWriter]:
     sw = StreamWriter(*args, **kwargs)
     try:
         yield sw

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -125,7 +125,7 @@ def save_method_file(path: str | Path, method: MethodType):
     ----------
     path : Path | str
         Path to save the method file
-    method : Method
+    method : MethodType
         Method to save
     """
     data = method._serialize()

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -10,7 +10,7 @@ from System.Text import Encoding
 
 from ._data import Method
 from ._data.measurement import Measurement
-from ._types import TechniqueType, TechniqueTypeCompatible
+from ._types import MethodType
 
 
 @contextmanager
@@ -87,9 +87,21 @@ def save_session_file(path: str | Path, measurements: list[Measurement]):
         session.Save(stream.BaseStream, str(path))
 
 
-def load_method_file(
-    path: str | Path, as_method: bool = False
-) -> TechniqueTypeCompatible | Method:
+def _load_method_file(path: str | Path) -> Method:
+    path = Path(path)
+
+    with stream_reader(str(path)) as stream:
+        if path.suffix == PalmSens.DataFiles.MethodFile2.FileExtension:
+            psmethod = PalmSens.DataFiles.MethodFile2.FromStream(stream)
+        else:
+            psmethod = PalmSens.DataFiles.MethodFile.FromStream(stream, str(path))
+
+    psmethod.MethodFilename = str(path.absolute())
+
+    return Method(psmethod=psmethod)
+
+
+def load_method_file(path: str | Path) -> MethodType:
     """Load a method file (.psmethod).
 
     Parameters
@@ -104,25 +116,11 @@ def load_method_file(
     method : Parameters
         Return method parameters
     """
-    path = Path(path)
-
-    with stream_reader(str(path)) as stream:
-        if path.suffix == PalmSens.DataFiles.MethodFile2.FileExtension:
-            psmethod = PalmSens.DataFiles.MethodFile2.FromStream(stream)
-        else:
-            psmethod = PalmSens.DataFiles.MethodFile.FromStream(stream, str(path))
-
-    psmethod.MethodFilename = str(path.absolute())
-
-    method = Method(psmethod=psmethod)
-
-    if as_method:
-        return method
-    else:
-        return method.to_settings()
+    method = _load_method_file(path)
+    return method.to_settings()
 
 
-def save_method_file(path: str | Path, method: TechniqueType):
+def save_method_file(path: str | Path, method: MethodType):
     """Load a method file (.psmethod).
 
     Parameters

--- a/python/src/pypalmsens/_io.py
+++ b/python/src/pypalmsens/_io.py
@@ -7,9 +7,10 @@ import PalmSens
 from System.IO import StreamReader, StreamWriter
 from System.Text import Encoding
 
+from pypalmsens._types import TechniqueType, TechniqueTypeCompatible
+
 from ._data import Method
 from ._data.measurement import Measurement
-from ._methods import BaseTechnique
 
 
 @contextmanager
@@ -86,7 +87,9 @@ def save_session_file(path: str | Path, measurements: list[Measurement]):
         session.Save(stream.BaseStream, str(path))
 
 
-def load_method_file(path: str | Path, as_method: bool = False) -> BaseTechnique | Method:
+def load_method_file(
+    path: str | Path, as_method: bool = False
+) -> TechniqueTypeCompatible | Method:
     """Load a method file (.psmethod).
 
     Parameters
@@ -119,7 +122,7 @@ def load_method_file(path: str | Path, as_method: bool = False) -> BaseTechnique
         return method.to_settings()
 
 
-def save_method_file(path: str | Path, method: BaseTechnique):
+def save_method_file(path: str | Path, method: TechniqueType):
     """Load a method file (.psmethod).
 
     Parameters

--- a/python/src/pypalmsens/_methods/base.py
+++ b/python/src/pypalmsens/_methods/base.py
@@ -8,7 +8,7 @@ import PalmSens
 from System.IO import StringWriter
 
 from .. import __version__
-from .._types import TechniqueType
+from .._types import MethodType
 from .base_model import BaseModel
 
 
@@ -46,14 +46,14 @@ class BaseTechnique(BaseModel, metaclass=ABCMeta):
         return self.model_dump()
 
     @classmethod
-    def from_dict(cls, obj: dict[str, Any]) -> TechniqueType:
+    def from_dict(cls, obj: dict[str, Any]) -> MethodType:
         """Structure technique instance from dict.
 
         Opposite of `.to_dict()`"""
         return cls.model_validate(obj)
 
     @classmethod
-    def from_method_id(cls, id: str) -> TechniqueType:
+    def from_method_id(cls, id: str) -> MethodType:
         """Create new instance of appropriate technique from method ID."""
         new = cls._registry[id]
         return new()
@@ -68,7 +68,7 @@ class BaseTechnique(BaseModel, metaclass=ABCMeta):
             return str(stream)
 
     @classmethod
-    def _from_psmethod(cls, psmethod: PalmSens.Method, /) -> TechniqueType:
+    def _from_psmethod(cls, psmethod: PalmSens.Method, /) -> MethodType:
         """Generate parameters from dotnet method object."""
         new = cls.from_method_id(psmethod.MethodID)
         new._update_params(psmethod)

--- a/python/src/pypalmsens/_methods/base.py
+++ b/python/src/pypalmsens/_methods/base.py
@@ -8,6 +8,7 @@ import PalmSens
 from System.IO import StringWriter
 
 from .. import __version__
+from .._types import TechniqueType
 from .base_model import BaseModel
 
 
@@ -45,14 +46,14 @@ class BaseTechnique(BaseModel, metaclass=ABCMeta):
         return self.model_dump()
 
     @classmethod
-    def from_dict(cls, obj: dict[str, Any]) -> BaseTechnique:
+    def from_dict(cls, obj: dict[str, Any]) -> TechniqueType:
         """Structure technique instance from dict.
 
         Opposite of `.to_dict()`"""
         return cls.model_validate(obj)
 
     @classmethod
-    def from_method_id(cls, id: str) -> BaseTechnique:
+    def from_method_id(cls, id: str) -> TechniqueType:
         """Create new instance of appropriate technique from method ID."""
         new = cls._registry[id]
         return new()
@@ -67,7 +68,7 @@ class BaseTechnique(BaseModel, metaclass=ABCMeta):
             return str(stream)
 
     @classmethod
-    def _from_psmethod(cls, psmethod: PalmSens.Method, /) -> BaseTechnique:
+    def _from_psmethod(cls, psmethod: PalmSens.Method, /) -> TechniqueType:
         """Generate parameters from dotnet method object."""
         new = cls.from_method_id(psmethod.MethodID)
         new._update_params(psmethod)

--- a/python/src/pypalmsens/_types.py
+++ b/python/src/pypalmsens/_types.py
@@ -110,6 +110,8 @@ AllowedFrequencyTypes = Literal['fixed', 'scan']
 
 
 class MethodType(Protocol):
+    """Methods with complete implementation in .NET."""
+
     @property
     def _use_hardware_sync(self) -> bool: ...
 
@@ -123,4 +125,6 @@ class MethodType(Protocol):
 
 
 class MethodTypeCompatible(Protocol):
+    """Methods with .NET implementation, or that can generate compatible MethodSCRIPT."""
+
     def _to_psmethod(self) -> PalmSens.Method: ...

--- a/python/src/pypalmsens/_types.py
+++ b/python/src/pypalmsens/_types.py
@@ -125,6 +125,6 @@ class MethodType(Protocol):
 
 
 class MethodTypeCompatible(Protocol):
-    """Methods with .NET implementation, or that can generate compatible MethodSCRIPT."""
+    """All methods, including MethodType and those that generate compatible MethodSCRIPT."""
 
     def _to_psmethod(self) -> PalmSens.Method: ...

--- a/python/src/pypalmsens/_types.py
+++ b/python/src/pypalmsens/_types.py
@@ -106,11 +106,12 @@ AllowedScanTypes = Literal['potential', 'time', 'fixed']
 """Possible scan types."""
 
 AllowedFrequencyTypes = Literal['fixed', 'scan']
-"""Possibl frequency types."""
+"""Possible frequency types."""
 
 
-class TechniqueType(Protocol):
-    _use_hardware_sync: bool
+class MethodType(Protocol):
+    @property
+    def _use_hardware_sync(self) -> bool: ...
 
     def to_dict(self) -> dict[str, Any]: ...
     def _serialize(self) -> str: ...
@@ -121,5 +122,5 @@ class TechniqueType(Protocol):
     def _update_psmethod_nested(self, psmethod: PalmSens.Method, /) -> None: ...
 
 
-class TechniqueTypeCompatible(Protocol):
+class MethodTypeCompatible(Protocol):
     def _to_psmethod(self) -> PalmSens.Method: ...

--- a/python/src/pypalmsens/_types.py
+++ b/python/src/pypalmsens/_types.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal, Protocol
+
+import PalmSens
 
 AllowedTimingStatus = Literal['Unknown', 'OK', 'OverStep']
 """Possible values for measurement timing status."""
@@ -105,3 +107,19 @@ AllowedScanTypes = Literal['potential', 'time', 'fixed']
 
 AllowedFrequencyTypes = Literal['fixed', 'scan']
 """Possibl frequency types."""
+
+
+class TechniqueType(Protocol):
+    _use_hardware_sync: bool
+
+    def to_dict(self) -> dict[str, Any]: ...
+    def _serialize(self) -> str: ...
+    def _update_params(self, psmethod: PalmSens.Method, /) -> None: ...
+    def _update_params_nested(self, psmethod: PalmSens.Method, /) -> None: ...
+    def _to_psmethod(self) -> PalmSens.Method: ...
+    def _update_psmethod(self, psmethod: PalmSens.Method, /) -> None: ...
+    def _update_psmethod_nested(self, psmethod: PalmSens.Method, /) -> None: ...
+
+
+class TechniqueTypeCompatible(Protocol):
+    def _to_psmethod(self) -> PalmSens.Method: ...

--- a/python/src/pypalmsens/types.py
+++ b/python/src/pypalmsens/types.py
@@ -12,6 +12,8 @@ from ._types import (
     AllowedReadingStatus,
     AllowedScanTypes,
     AllowedTimingStatus,
+    TechniqueType,
+    TechniqueTypeCompatible,
 )
 
 __all__ = [
@@ -24,4 +26,6 @@ __all__ = [
     'AllowedReadingStatus',
     'AllowedScanTypes',
     'AllowedTimingStatus',
+    'TechniqueType',
+    'TechniqueTypeCompatible',
 ]

--- a/python/src/pypalmsens/types.py
+++ b/python/src/pypalmsens/types.py
@@ -12,8 +12,8 @@ from ._types import (
     AllowedReadingStatus,
     AllowedScanTypes,
     AllowedTimingStatus,
-    TechniqueType,
-    TechniqueTypeCompatible,
+    MethodType,
+    MethodTypeCompatible,
 )
 
 __all__ = [
@@ -26,6 +26,6 @@ __all__ = [
     'AllowedReadingStatus',
     'AllowedScanTypes',
     'AllowedTimingStatus',
-    'TechniqueType',
-    'TechniqueTypeCompatible',
+    'MethodType',
+    'MethodTypeCompatible',
 ]

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -36,7 +36,7 @@ def test_save_load_method(tmpdir):
     cv = ps.CyclicVoltammetry()
     ps.save_method_file(path=path, method=cv)
 
-    method_cv2 = ps._io._load_method_file(path=path, as_method=True)
+    method_cv2 = ps._io._load_method_file(path=path)
 
     assert method_cv2.filename == path
 

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -36,7 +36,7 @@ def test_save_load_method(tmpdir):
     cv = ps.CyclicVoltammetry()
     ps.save_method_file(path=path, method=cv)
 
-    method_cv2 = ps.load_method_file(path=path, as_method=True)
+    method_cv2 = ps._load_method_file(path=path, as_method=True)
 
     assert method_cv2.filename == path
 

--- a/python/tests/test_io.py
+++ b/python/tests/test_io.py
@@ -36,7 +36,7 @@ def test_save_load_method(tmpdir):
     cv = ps.CyclicVoltammetry()
     ps.save_method_file(path=path, method=cv)
 
-    method_cv2 = ps._load_method_file(path=path, as_method=True)
+    method_cv2 = ps._io._load_method_file(path=path, as_method=True)
 
     assert method_cv2.filename == path
 


### PR DESCRIPTION
This PR sorts out a few issues with the type checking.

It introduces 2 new types (Protocol):

- `ps.types.MethodType` (for methods with first class support in .NET)
- `ps.types.MethodTypeCompatible` (for all methods, including those like BatteryCycling, that generate methodscript)

This solves some long-standing issues, and we now have a properly documented public type for methods in InstrumentMananger and the likes.