### PR TITLE
Fix double newlines in serialize to `.psmethod`

### DIFF
--- a/python/src/pypalmsens/_methods/base.py
+++ b/python/src/pypalmsens/_methods/base.py
@@ -15,6 +15,7 @@ from .base_model import BaseModel
 @contextmanager
 def string_writer(*args, **kwargs):
     stream = StringWriter(*args, **kwargs)
+    stream.NewLine = '\n'
     try:
         yield stream
     finally:

--- a/python/src/pypalmsens/_methods/mixed_mode.py
+++ b/python/src/pypalmsens/_methods/mixed_mode.py
@@ -290,12 +290,12 @@ StageType = Annotated[
 
 
 class MixedMode(
-    BaseTechnique,
     mixins.CurrentRangeMixin,
     mixins.PretreatmentMixin,
     mixins.PostMeasurementMixin,
     mixins.DataProcessingMixin,
     mixins.GeneralMixin,
+    BaseTechnique,
 ):
     """Create mixed mode method parameters.
 


### PR DESCRIPTION
Fix bug introduced in # 378, which cause double newlines in the .psmethod file on Windows.
The reason is that .NET StreamWriter defaults to /r/n, where Python expects /n.

This only affected MixedMode in the Windows tests.

https://docs.python.org/3/library/functions.html#open

