### PR TITLE
Remove polyfill js

### DIFF
--- a/python/zensical.toml
+++ b/python/zensical.toml
@@ -83,7 +83,6 @@ extra_css = [
 ]
 
 extra_javascript = [
-  "https://polyfill.io/v3/polyfill.min.js?features:es6",
   "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js",
 ]
 


### PR DESCRIPTION
This PR removes the polyfill library. It was causing a popup requiring username/password. Polyfill itself is no longer needed.

See also https://github.com/squidfunk/mkdocs-material/issues/7295