### PR TITLE
Add missing fields for the GEIS technique

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,5 @@
 [![Tests](https://github.com/PalmSens/PalmSens_SDK/actions/workflows/python-tests.yml/badge.svg)](https://github.com/PalmSens/PalmSens_SDK/actions/workflows/python-tests.yml)
-![Coverage](https://img.shields.io/badge/coverage-88%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-89%25-brightgreen)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pypalmsens)](https://pypi.org/project/pypalmsens/)
 [![PyPI](https://img.shields.io/pypi/v/pypalmsens.svg?style=flat)](https://pypi.org/project/pypalmsens/)
 

--- a/python/src/pypalmsens/_methods/techniques.py
+++ b/python/src/pypalmsens/_methods/techniques.py
@@ -1760,7 +1760,7 @@ class ElectrochemicalImpedanceSpectroscopy(
 
     - Scan: a frequency scan is performed starting at the given `max_frequency`
         to the `min_frequency`.
-    - Fixed: a single frequency given by 'fixed_frequencya is applied for
+    - Fixed: a single frequency given by 'fixed_frequency is applied for
         the given duration or at each potential step or time interval.
     """
 
@@ -1988,8 +1988,18 @@ class GalvanostaticImpedanceSpectroscopy(
     id: Literal['gis'] = 'gis'
     """Unique method identifier."""
 
+    _SCAN_TYPES: tuple[AllowedScanTypes, ...] = (
+        'current',
+        'time',
+        'fixed',
+    )
+    _FREQ_TYPES: tuple[AllowedFrequencyTypes, ...] = ('fixed', 'scan')
+
     applied_current_range: AllowedCurrentRanges = '100uA'
     """Applied current range.
+
+    This is the range in which the specified current values (such as `ac_current`,
+    `begin_current`, or `step_current) will be applied.
 
     See `pypalmsens.settings.AllowedCurrentRanges` for options."""
 
@@ -1997,43 +2007,162 @@ class GalvanostaticImpedanceSpectroscopy(
     """Equilibration time in s."""
 
     ac_current: float = 0.01
-    """AC current in applied current range RMS."""
+    """AC current expressed in the applied current range RMS."""
 
     dc_current: float = 0.0
-    """DC current in applied current range."""
+    """DC current expressed in the applied current range."""
 
-    min_frequency: float = 1_000
-    """Minimum frequency in Hz."""
+    frequency_type: AllowedFrequencyTypes = 'scan'
+    """Whether to measure a single frequency or scan over a range of frequencies.
 
-    max_frequency: float = 50_000
-    """Maximum frequency in Hz."""
+    Possible values: 'scan', 'fixed'.
+
+    - Scan: a frequency scan is performed starting at the given `max_frequency`
+        to the `min_frequency`.
+    - Fixed: a single frequency given by `fixed_frequency` is applied for
+        the given duration or at each potential step or time interval.
+    """
+
+    fixed_frequency: float = 1_000
+    """Fixed frequency in Hz (fixed frequency only)."""
+
+    min_frequency: float = 5.0
+    """Minimum frequency in Hz (frequency scan only)."""
+
+    max_frequency: float = 10_000
+    """Maximum frequency in Hz (frequency scan only)."""
 
     n_frequencies: int = 11
-    """Number of frequencies."""
+    """Number of frequencies (frequency scan only).
+
+    Defines the range of frequencies to apply between the `max_frequency` and
+    `min_frequency`. For example, a value of 11 will measure at 11 frequencies,
+    including both end points.
+    """
+
+    scan_type: AllowedScanTypes = 'fixed'
+    """Whether a single or multiple frequency scans are performed.
+
+    Possible values: 'current', 'time', 'fixed'.
+
+    - Fixed scan: perform a single scan (default).
+    - Time scan: scans are repeated for a specific amount of time at a specific interval.
+    - Current scan: scans are repeated over a range of current values, starting at
+        `begin_current` and ending at `end_current` with step size `step_current`.
+        At each DC current level, a single fixed frequency or frequency scan is applied.
+    """
+
+    run_time: float = 10.0
+    """Minimal run time in seconds in s (time scan only).
+
+    For example, if a frequency scan takes 18 seconds and is measured
+    at an interval of 19 seconds for a `run_time` of 40 seconds, then
+    three iterations will be performed."""
+
+    interval_time: float = 0.1
+    """The interval at which a measurement iteration should be performed in s (time scan only).
+
+    The minimum interval time between each data point (`frequency_type='fixed') or
+    between each frequency scan (`frequency_type='scan').
+    We recommend a time higher than the required time to measure the data point or perform the
+    frequency scan + overhead time. While it's possible to use a shorter time, doing so may
+    lead to incorrect impedance calculations.
+
+    If a measurement iteration takes longer than the interval time the next measurement
+    will not be triggered until after it has been completed.
+    """
+
+    begin_current: float = 0.0
+    """Current at which the scan starts expressed in the applied current range (current scan only)."""
+
+    end_current: float = 0.0
+    """Current at which the scan ends expressed in the applied current range (current scan only)."""
+
+    step_current: float = 0.01
+    """Current step size expressed in the applied current range (current scan only).
+
+    This sets the increment to be used between `begin_current` and `end_current`.
+    """
+
+    min_sampling_time: float = Field(0.5, gt=0)
+    """Minimum sampling time in s.
+
+    Each measurement point of the impedance spectrum is performed
+    during the period specified by `min_sampling_time`.
+
+    This means that the number of measured sine waves is equal to `min_sampling_time * frequency`.
+    If this value is less than 1 sine wave, the sampling is extended to `1 / frequency`.
+
+    So for a measurement at a `frequency`, at least one complete sine wave is measured.
+    Reasonable values for the sampling are in the range of 0.1 to 1 s."""
+
+    max_equilibration_time: float = 5.0
+    """Max equilibration time in s.
+
+    The EIS measurement requires a stationary state.
+    This means that before the actual measurement starts, the sine wave is
+    applied during `max_equilibration_time` only to reach the stationary state.
+
+    The maximum number of equilibration sine waves is however 5.
+
+    The minimum number of equilibration sines is set to 1, but for very
+    low frequencies, this time is limited by `max_equilibration_time`.
+
+    The maximum time to wait for stationary state is determined by the
+    value of this parameter. A reasonable value might be 5 seconds.
+    In this case this parameter is only relevant when the lowest frequency
+    is less than 1/5 s so 0.2 Hz.
+    """
 
     @override
     def _update_psmethod(self, psmethod: PalmSens.Method, /):
         """Update method with galvanic impedance spectroscopy settings."""
 
-        psmethod.ScanType = enumScanType.Fixed
-        psmethod.FreqType = enumFrequencyType.Scan
+        if self.scan_type == 'current':
+            # psmethod.BeginCurrent is an alias for psmethod.Current
+            psmethod.BeginCurrent = self.begin_current
+            psmethod.EndCurrent = self.end_current
+            psmethod.StepCurrent = self.step_current
+        elif self.scan_type == 'time':
+            psmethod.RunTime = self.run_time
+            psmethod.IntervalTime = self.interval_time
+            psmethod.Idc = self.dc_current
+        else:
+            psmethod.Idc = self.dc_current
+
+        psmethod.ScanType = enumScanType(self._SCAN_TYPES.index(self.scan_type))
+        psmethod.FreqType = enumFrequencyType(self._FREQ_TYPES.index(self.frequency_type))
         psmethod.AppliedCurrentRange = cr_string_to_enum(self.applied_current_range)
         psmethod.EquilibrationTime = self.equilibration_time
         psmethod.Iac = self.ac_current
-        psmethod.Idc = self.dc_current
+        psmethod.FixedFrequency = self.fixed_frequency
         psmethod.nFrequencies = self.n_frequencies
         psmethod.MaxFrequency = self.max_frequency
         psmethod.MinFrequency = self.min_frequency
+        psmethod.SamplingTime = self.min_sampling_time
+        psmethod.MaxEqTime = self.max_equilibration_time
 
     @override
     def _update_params(self, psmethod: PalmSens.Method, /):
+        self.scan_type = self._SCAN_TYPES[int(psmethod.ScanType)]
+        self.frequency_type = self._FREQ_TYPES[int(psmethod.FreqType)]
         self.applied_current_range = cr_enum_to_string(psmethod.AppliedCurrentRange)
         self.equilibration_time = single_to_double(psmethod.EquilibrationTime)
         self.ac_current = single_to_double(psmethod.Iac)
         self.dc_current = single_to_double(psmethod.Idc)
         self.n_frequencies = psmethod.nFrequencies
+
+        self.fixed_frequency = single_to_double(psmethod.FixedFrequency)
         self.max_frequency = single_to_double(psmethod.MaxFrequency)
         self.min_frequency = single_to_double(psmethod.MinFrequency)
+
+        if self.scan_type == 'current':
+            self.begin_current = single_to_double(psmethod.BeginCurrent)
+            self.end_current = single_to_double(psmethod.EndCurrent)
+            self.step_current = single_to_double(psmethod.StepCurrent)
+        elif self.scan_type == 'time':
+            self.run_time = single_to_double(psmethod.RunTime)
+            self.interval_time = single_to_double(psmethod.IntervalTime)
 
 
 class FastGalvanostaticImpedanceSpectroscopy(

--- a/python/src/pypalmsens/_types.py
+++ b/python/src/pypalmsens/_types.py
@@ -102,7 +102,7 @@ See the device documentation or query the instrument manager
 for supported potential ranges."""
 
 
-AllowedScanTypes = Literal['potential', 'time', 'fixed']
+AllowedScanTypes = Literal['potential', 'current', 'time', 'fixed']
 """Possible scan types."""
 
 AllowedFrequencyTypes = Literal['fixed', 'scan']

--- a/python/tests/test_energy.py
+++ b/python/tests/test_energy.py
@@ -45,8 +45,8 @@ class BC:
         assert isinstance(measurement, ps.data.Measurement)
 
         expected_curves: list[dict[str, Any]] = [
-            {'x': 'Time', 'y': 'Potential', 'min_len': 6},
-            {'x': 'Time', 'y': 'Current', 'min_len': 6},
+            {'x': 'Time', 'y': 'Potential', 'min_len': 4},
+            {'x': 'Time', 'y': 'Current', 'min_len': 4},
             {'x': 'Potential', 'y': 'Potential', 'min_len': 1},
             {'x': 'Potential', 'y': 'Potential', 'min_len': 1},
         ]

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -80,7 +80,7 @@ def test_measure_stream_cv_multiple_scans(tmpdir):
         scanrate=5,
         # use a fixed current range
         # because Measurement seems to do a post-processing step in a different CR ?
-        current_range={'1uA'},
+        current_range='1uA',
     )
 
     _ = _test_stream(method=method, path=path)

--- a/python/tests/test_techniques.py
+++ b/python/tests/test_techniques.py
@@ -966,51 +966,133 @@ class GIS:
 
     @staticmethod
     def validate(measurement):
-        assert measurement
-        assert isinstance(measurement, ps.data.Measurement)
+        check_eis_measurement(measurement)
 
-        for curve in measurement.curves:
-            assert curve.n_points >= 5
+        eis_datas = measurement.eis_data
+        assert len(eis_datas) == 1
+        for eis_data in eis_datas:
+            assert eis_data.n_points == 5
+            assert eis_data.n_subscans == 0
+            assert eis_data.n_frequencies == 7
 
-        dataset = measurement.dataset
-        assert len(dataset) == 18
 
-        assert dataset.array_names == {
-            "Capacitance'",
-            "Capacitance''",
-            'Capacitance',
-            'Eac',
-            'Frequency',
-            'Iac',
-            'Idc',
-            'Phase',
-            'Y',
-            'YIm',
-            'YRe',
-            'Z',
-            'ZIm',
-            'ZRe',
-            'mEdc',
-            'miDC',
-            'potential',
-            'time',
-        }
-        assert dataset.array_quantities == {
-            "-C''",
-            '-Phase',
-            "-Z''",
-            'C',
-            "C'",
-            'Current',
-            'Frequency',
-            'Potential',
-            'Time',
-            'Y',
-            "Y'",
-            "Y''",
-            'Z',
-            "Z'",
-        }
+class GIS_cur_fixed:
+    id = 'gis'
+    kwargs = {
+        'n_frequencies': 5,
+        'max_frequency': 1e5,
+        'min_frequency': 1e3,
+        'scan_type': 'current',
+        'frequency_type': 'fixed',
+        'begin_current': 0.0,
+        'end_current': -0.1,
+        'step_current': 0.1,
+    }
+
+    @staticmethod
+    def validate(measurement):
+        check_eis_measurement(measurement)
+
+        eis_datas = measurement.eis_data
+        assert len(eis_datas) == 1
+        for eis_data in eis_datas:
+            assert eis_data.n_points == 2
+            assert eis_data.n_subscans == 0
+            assert eis_data.n_frequencies == 1
+
+
+class GIS_cur_scan:
+    id = 'gis'
+    kwargs = {
+        'n_frequencies': 5,
+        'max_frequency': 1e5,
+        'min_frequency': 1e3,
+        'scan_type': 'current',
+        'frequency_type': 'scan',
+        'begin_current': 0.0,
+        'end_current': -0.1,
+        'step_current': 0.1,
+    }
+
+    @staticmethod
+    def validate(measurement):
+        check_eis_measurement(measurement)
+
+        eis_datas = measurement.eis_data
+        assert len(eis_datas) == 1
+        for eis_data in eis_datas:
+            assert eis_data.n_points == 10
+            assert eis_data.n_subscans == 2
+            assert eis_data.n_frequencies == 5
+
+
+class GIS_time_fixed:
+    id = 'gis'
+    kwargs = {
+        'n_frequencies': 5,
+        'max_frequency': 1e5,
+        'min_frequency': 1e3,
+        'scan_type': 'time',
+        'frequency_type': 'fixed',
+        'run_time': 1.3,
+    }
+
+    @staticmethod
+    def validate(measurement):
+        check_eis_measurement(measurement)
+
+        eis_datas = measurement.eis_data
+        assert len(eis_datas) == 1
+        for eis_data in eis_datas:
+            # n_points is tricky to reproduce because of device specific timings?
+            assert eis_data.n_points > 1
+            assert eis_data.n_subscans == 0
+            assert eis_data.n_frequencies == 1
+
+
+class GIS_time_scan:
+    id = 'gis'
+    kwargs = {
+        'n_frequencies': 5,
+        'max_frequency': 1e5,
+        'min_frequency': 1e3,
+        'scan_type': 'time',
+        'frequency_type': 'scan',
+        'run_time': 0.4,
+    }
+
+    @staticmethod
+    def validate(measurement):
+        check_eis_measurement(measurement)
+
+        eis_datas = measurement.eis_data
+        assert len(eis_datas) == 1
+        for eis_data in eis_datas:
+            assert eis_data.n_points == 10
+            assert eis_data.n_subscans == 2
+            assert eis_data.n_frequencies == 5
+
+
+class GIS_single_point:
+    id = 'gis'
+    kwargs = {
+        'n_frequencies': 5,
+        'max_frequency': 1e5,
+        'min_frequency': 1e3,
+        'scan_type': 'fixed',
+        'frequency_type': 'fixed',
+    }
+
+    @staticmethod
+    def validate(measurement):
+        check_eis_measurement(measurement)
+
+        eis_datas = measurement.eis_data
+        assert len(eis_datas) == 1
+        for eis_data in eis_datas:
+            assert eis_data.n_points == 1
+            assert eis_data.n_subscans == 0
+            assert eis_data.n_frequencies == 1
 
 
 class FGIS:
@@ -1237,7 +1319,11 @@ class MM:
         EIS_time_fixed,
         EIS_single_point,
         FIS,
-        GIS,
+        GIS_cur_fixed,
+        GIS_cur_scan,
+        GIS_time_scan,
+        GIS_time_fixed,
+        GIS_single_point,
         FGIS,
         MS,
         MM,
@@ -1293,6 +1379,11 @@ def test_measure(manager, method):
         EIS_single_point,
         FIS,
         GIS,
+        GIS_cur_fixed,
+        GIS_cur_scan,
+        GIS_time_scan,
+        GIS_time_fixed,
+        GIS_single_point,
         FGIS,
         MS,
         MM,


### PR DESCRIPTION
The GEIS class lacked configurable fields compared to EIS. This PR adds the missing parameters to the GEIS technique.

- min_sampling_time
- max_equilibration_time
- scan_type + related
- freq_type + related

