### PR TITLE
Add ConstantPower and ConstantResistance methods

### DIFF
--- a/python/docs/zensical/reference/energy/constant_power.md
+++ b/python/docs/zensical/reference/energy/constant_power.md
@@ -1,6 +1,6 @@
-# Battery Cycling
+# Constant Power
 
-This page documents the Battery Cycling (`BC`) method.
+This page documents the Constant Power (`DCP`) method.
 
 !!! Warning "Experimental"
 
@@ -8,6 +8,6 @@ This page documents the Battery Cycling (`BC`) method.
 
     We welcome any [feedback and suggestions](https://github.com/palmsens/palmsens_sdk/issues) before making them a permanent part of PyPalmSens.
 
-::: pypalmsens.energy.experimental_BatteryCycling
+::: pypalmsens.energy.experimental_ConstantPower
     options:
       members_order: source

--- a/python/docs/zensical/reference/energy/constant_resistance.md
+++ b/python/docs/zensical/reference/energy/constant_resistance.md
@@ -1,6 +1,6 @@
-# Battery Cycling
+# Constant Resistance
 
-This page documents the Battery Cycling (`BC`) method.
+This page documents the Constant Resistance (`DCR`) method.
 
 !!! Warning "Experimental"
 
@@ -8,6 +8,6 @@ This page documents the Battery Cycling (`BC`) method.
 
     We welcome any [feedback and suggestions](https://github.com/palmsens/palmsens_sdk/issues) before making them a permanent part of PyPalmSens.
 
-::: pypalmsens.energy.experimental_BatteryCycling
+::: pypalmsens.energy.experimental_ConstantResistance
     options:
       members_order: source

--- a/python/docs/zensical/reference/energy/index.md
+++ b/python/docs/zensical/reference/energy/index.md
@@ -18,7 +18,7 @@ In the energy submodule you will find new methods only available in PyPalmSens.
 - [experimental_ConstantPower][pypalmsens.energy.experimental_ConstantPower] (Discharge at constant power)
 - [experimental_ConstantResistance][pypalmsens.energy.experimental_ConstantResistance] (Discharge at constant resistance)
 
-For example to set up a battery cyclings experiment:
+For example to set up a battery cycling experiment:
 
 ```python
 >>> import pypalmsens as ps

--- a/python/docs/zensical/reference/energy/index.md
+++ b/python/docs/zensical/reference/energy/index.md
@@ -2,17 +2,21 @@
 
 This section contains a listing of all available energy techniques in PyPalmSens.
 
+In the energy submodule you will find new methods only available in PyPalmSens.
+
 !!! Note
 
     These methods are based on MethodSCRIPT and therefore behave differently than the other [electrochemistry](../methods/) or [corrosion](./corrosion/) techniques.
 
 !!! Warning "Experimental"
 
-    Methods with the `experimental_` prefix are things that we're still working on or trying to understand. In the energy submodule you will find new, experimental methods only available in PyPalmSens.
+    Classes with the `experimental_` prefix are things that we're still working on or trying to understand. That means these classes are subject to change.
 
-    These methods are subject to change or removal. We welcome any [feedback and suggestions](https://github.com/palmsens/palmsens_sdk/issues) before making them a permanent part of PyPalmSens.
+    We welcome any [feedback and suggestions](https://github.com/palmsens/palmsens_sdk/issues) before making them a permanent part of PyPalmSens.
 
 - [experimental_BatteryCycling][pypalmsens.energy.experimental_BatteryCycling] (CC-CV-CC)
+- [experimental_ConstantPower][pypalmsens.energy.experimental_ConstantPower] (Discharge at constant power)
+- [experimental_ConstantResistance][pypalmsens.energy.experimental_ConstantResistance] (Discharge at constant resistance)
 
 For example to set up a battery cyclings experiment:
 
@@ -28,3 +32,5 @@ For example to set up a battery cyclings experiment:
 ## Classes
 
 - [`pypalmsens.energy.experimental_BatteryCycling`][pypalmsens.energy.experimental_BatteryCycling]
+- [`pypalmsens.energy.experimental_ConstantPower`][pypalmsens.energy.experimental_ConstantPower]
+- [`pypalmsens.energy.experimental_ConstantResistance`][pypalmsens.energy.experimental_ConstantResistance]

--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -15,7 +15,7 @@ from pydantic.dataclasses import dataclass
 from System import EventHandler
 from System.Threading.Tasks import Task
 
-from pypalmsens._methods.adapters import EnergyTechniqueType
+from pypalmsens._methods.energy import BaseMethodScriptTechnique
 from pypalmsens._types import MethodTypeCompatible
 
 from .._data import DataSet
@@ -307,8 +307,8 @@ class MeasurementManagerAsync:
 
         assert self.last_measurement
 
-        if isinstance(method, EnergyTechniqueType):
-            self.last_measurement._psmeasurement.Title = method._name
+        if isinstance(method, BaseMethodScriptTechnique):
+            self.last_measurement._psmeasurement.Title = method._name  # type: ignore
 
         return self.last_measurement
 

--- a/python/src/pypalmsens/_methods/adapters.py
+++ b/python/src/pypalmsens/_methods/adapters.py
@@ -39,7 +39,10 @@ TechniqueType = Annotated[
     Field(discriminator='id'),
 ]
 
-EnergyTechniqueType = energy.experimental_BatteryCycling
+EnergyTechniqueType = Annotated[
+    energy.BatteryCycling | energy.ConstantPower | energy.ConstantResistance,
+    Field(discriminator='id'),
+]
 
 technique_adapter: TypeAdapter[TechniqueType] = TypeAdapter(TechniqueType)
 energy_technique_adapter: TypeAdapter[EnergyTechniqueType] = TypeAdapter(EnergyTechniqueType)

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Literal
 
 import PalmSens
-from jinja2 import Environment, PackageLoader, select_autoescape
+from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
 from pydantic import BaseModel, Field
 
 from .. import __version__
@@ -14,6 +14,7 @@ env = Environment(
     loader=PackageLoader('pypalmsens'),
     autoescape=select_autoescape(),
     keep_trailing_newline=True,
+    undefined=StrictUndefined,
 )
 
 
@@ -29,7 +30,11 @@ class BaseMethodScriptTechnique(BaseModel):
             Complete MethodScript code for this method.
         """
         template = env.get_template(self._template)
-        return template.render(model=self, timestamp=datetime.today(), version=__version__)
+        return template.render(
+            model=self,
+            timestamp=datetime.today(),
+            version=__version__,
+        )
 
     def to_methodscript(self) -> MethodScript:
         """Convert to MethodSCRIPT class.

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -18,6 +18,8 @@ env = Environment(
 
 
 class BaseMethodScriptTechnique(BaseModel):
+    _template: str = ''
+
     def render(self) -> str:
         """Render the template with model parameters.
 
@@ -26,7 +28,7 @@ class BaseMethodScriptTechnique(BaseModel):
         script : str
             Complete MethodScript code for this method.
         """
-        template = env.get_template('battery_cycling.mscr')
+        template = env.get_template(self._template)
         return template.render(model=self, timestamp=datetime.today(), version=__version__)
 
     def to_methodscript(self) -> MethodScript:
@@ -84,6 +86,9 @@ class BatteryCycling(BaseMethodScriptTechnique):
     https://www.palmsens.com/knowledgebase-article/advanced-battery-cycling-with-methodscript/
     """
 
+    _name: str = 'Battery Cycling'
+    _template: str = 'battery_cycling.mscr'
+
     id: Literal['bc'] = 'bc'
     """Unique method identifier."""
 
@@ -129,9 +134,6 @@ class BatteryCycling(BaseMethodScriptTechnique):
     Adjusts sampling on instrument to account for mains frequency.
     Set to 50 Hz or 60 Hz depending on your region (default: 50)."""
 
-    _name: str = 'Battery Cycling (experimental)'
-    _template: str = 'battery_cycling.mscr'
-
 
 class ConstantResistance(BaseMethodScriptTechnique):
     """Discharge at Constant Resistance load.
@@ -156,8 +158,11 @@ class ConstantResistance(BaseMethodScriptTechnique):
     Send live I-V versus time at a defined time interval.
     The discharge current is converted to positive values."""
 
-    _name: str = 'Constant Resistance (experimental)'
+    _name: str = 'Constant Resistance'
     _template: str = 'constant_resistance.mscr'
+
+    id: Literal['dcr'] = 'dcr'
+    """Unique method identifier."""
 
     load: int = -80
     """Constant resistance load in Ohm (make it negative for discharging)."""
@@ -201,8 +206,11 @@ class ConstantPower(BaseMethodScriptTechnique):
     Send live I-V versus time at a defined time interval.
     The discharge current is converted to positive values."""
 
-    _name: str = 'Constant Power (experimental)'
+    _name: str = 'Constant Power'
     _template: str = 'constant_power.mscr'
+
+    id: Literal['dcp'] = 'dcp'
+    """Unique method identifier."""
 
     power: int = -200
     """Constant power in Watt (negative for discharging)."""

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -32,7 +32,7 @@ class BaseMethodScriptTechnique(BaseModel):
         template = env.get_template(self._template)
         return template.render(
             model=self,
-            timestamp=datetime.today(),
+            timestamp=datetime.today().replace(microsecond=0),
             version=__version__,
         )
 

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -58,11 +58,6 @@ class BatteryCycling(BaseMethodScriptTechnique):
 
     Note: This method is experimental and may be subject to change.
 
-    Supported devices:
-
-    - Nexus
-    - EmStat4 series (EmStat4S, EmStat4X, MultiEmStat4)
-
     This method implements CC-CV-CC Cycling with Delta-I-V and Passed Charge.
 
     Each cycle consist of:
@@ -89,6 +84,11 @@ class BatteryCycling(BaseMethodScriptTechnique):
 
     The underlying methodscript is described in this application note:
     https://www.palmsens.com/knowledgebase-article/advanced-battery-cycling-with-methodscript/
+
+    Supported devices:
+
+    - Nexus
+    - EmStat4 series (EmStat4S, EmStat4X, MultiEmStat4)
     """
 
     _name: str = 'Battery Cycling'
@@ -145,23 +145,27 @@ class ConstantResistance(BaseMethodScriptTechnique):
 
     Note: This method is experimental and may be subject to change.
 
+    This method implements a single step for discharging a battery or
+    capacitor at a constant resistance load (Volt per Ampère).
+
+    This simulates the demand of very simple loads, like a filament lamp
+    or a simple DC motor.
+    While the battery is discharging, its voltage drops and the current
+    provided also decreases in proportion to the constant resistance.
+
+    The applied current is refreshed at the defined time interval.
+
+    The discharge is finished when the lower target voltage is reached
+    (the lower cut-off voltage limit) or after the defined duration.
+
+    Send live I-V versus time at a defined time interval.
+    The discharge current is converted to positive values.
+
     Supported devices:
 
     - Nexus
     - EmStat4 series (EmStat4S, EmStat4X, MultiEmStat4)
-
-    This method implements a single step for discharging a battery or
-    capacitor at a constant resistance load (Volt per Ampère). This
-    simulates the demand of very simple loads, like a filament lamp
-    or a simple DC motor. While the battery is discharging, its voltage
-    drops and the current provided also decreases in proportion to the
-    constant resistance. The applied current is refreshed at the defined
-    time interval. The discharge is finished when the lower target
-    voltage is reached (the lower cut-off voltage limit) or after the
-    defined duration.
-
-    Send live I-V versus time at a defined time interval.
-    The discharge current is converted to positive values."""
+    """
 
     _name: str = 'Constant Resistance'
     _template: str = 'constant_resistance.mscr'
@@ -196,23 +200,27 @@ class ConstantPower(BaseMethodScriptTechnique):
 
     Note: This method is experimental and may be subject to change.
 
+    This method implements a single step for discharging a battery or
+    capacitor at a constant power rate (Volt x Ampère).
+
+    This simulates the demand of electronic devices when performing a
+    specific task, i.e. a smartphone playing a video.
+    While the battery is discharging, its voltage drops and the
+    demanded current increases in order to maintain the set power.
+
+    The applied current is refreshed at the defined time interval.
+
+    The discharge is finished when the lower target voltage is reached
+    (the lower cut-off voltage limit) or after the defined duration.
+
+    Send live I-V versus time at a defined time interval.
+    The discharge current is converted to positive values.
+
     Supported devices:
 
     - Nexus
     - EmStat4 series (EmStat4S, EmStat4X, MultiEmStat4)
-
-    This method implements a single step for discharging a battery or
-    capacitor at a constant power rate (Volt x Ampère). This simulates
-    the demand of electronic devices when performing a specific task,
-    i.e. a smartphone playing a video. While the battery is discharging,
-    its voltage drops and the demanded current increases in order to
-    maintain the set power. The applied current is refreshed at the defined
-    time interval. The discharge is finished when the lower target
-    voltage is reached (the lower cut-off voltage limit) or after
-    the defined duration.
-
-    Send live I-V versus time at a defined time interval.
-    The discharge current is converted to positive values."""
+    """
 
     _name: str = 'Constant Power'
     _template: str = 'constant_power.mscr'

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -181,6 +181,9 @@ class ConstantResistance(BaseMethodScriptTechnique):
     interval: int = Field(1, ge=0)
     """The interval time in s of each data point."""
 
+    cell_on_ocp: bool = False
+    """Turns cell on with the measured OCP (Nexus only)."""
+
     mains_frequency: Literal[50, 60] = 50
     """Set the DC mains filter in Hz.
 
@@ -228,6 +231,9 @@ class ConstantPower(BaseMethodScriptTechnique):
 
     interval: int = Field(1, ge=0)
     """The interval time in s of each data point."""
+
+    cell_on_ocp: bool = False
+    """Turns cell on with the measured OCP (Nexus only)."""
 
     mains_frequency: Literal[50, 60] = 50
     """Set the DC mains filter in Hz.

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -17,8 +17,37 @@ env = Environment(
 )
 
 
-class experimental_BatteryCycling(BaseModel):
-    """Battery cycling method parameters.
+class BaseMethodScriptTechnique(BaseModel):
+    def render(self) -> str:
+        """Render the template with model parameters.
+
+        Returns
+        -------
+        script : str
+            Complete MethodScript code for this method.
+        """
+        template = env.get_template('battery_cycling.mscr')
+        return template.render(model=self, timestamp=datetime.today(), version=__version__)
+
+    def to_methodscript(self) -> MethodScript:
+        """Convert to MethodSCRIPT class.
+
+        Returns
+        -------
+        method: MethodScript
+            MethodScript class.
+        """
+        script = self.render()
+        return MethodScript(script=script)
+
+    def _to_psmethod(self) -> PalmSens.Method:
+        """Convert parameters to dotnet method."""
+        method = self.to_methodscript()
+        return method._to_psmethod()
+
+
+class BatteryCycling(BaseMethodScriptTechnique):
+    """Battery cycling CC-CV-CC.
 
     Note: This method is experimental and may be subject to change.
 
@@ -27,14 +56,29 @@ class experimental_BatteryCycling(BaseModel):
     - Nexus
     - EmStat4 series (EmStat4S, EmStat4X, MultiEmStat4)
 
-    This method implements CC-CV-CC Cycling with Delta-I-V and Qpass:
+    This method implements CC-CV-CC Cycling with Delta-I-V and Passed Charge.
 
-    1. With Chronopotentiometry and Chronoamperometry to charge a cell and a Constant
-       current followed by Constant Coltage (CC-CV).
-    2. With Chronopotentiometry discharge the cell at a constant current (CC).
-    3. Store the charge transferred during each charge and discharge step.
-    4. Send I-V verus time data, and the capacity per charge-discharge step (Qpass).
-       The charge values are absolute and are converted to mAh.
+    Each cycle consist of:
+
+    1. Charge at a CC (Constant Current) using Chronopotentiometry.
+       When the target voltage is reached (the upper cut-off voltage limit),
+       switch to CV (Constant Voltage) using Chronoamperometry and maintain
+       the applied voltage for a defined period time or until the minimum
+       current is reached (the lower cut-off current limit).
+    2. Discharge at a Constant Current (using Chronopotentiometry) until
+       the lower target voltage is reached (the lower cut-off voltage limit).
+    3. Plot a point at defined time intervals.
+    4. Send I-V versus time data
+    5. Send the capacity per charge / discharge step, also known as passed charge (Qpass).
+       The capacity values are absolute and are converted to mAh.
+
+    Alternatively for point 3, use "deltas" to reduce data transfer and optimize points.
+
+    The time interval will be used for controlling, but some points may be skipped:
+
+    - Delta V: when voltage is being measured, plot a point only when a certain variation is reached.
+    - Delta I: when current is being measured, plot a point only when a certain variation is reached.
+    - Delta t: plot a point at this defined interval anyway, even if the variation is not met.
 
     The underlying methodscript is described in this application note:
     https://www.palmsens.com/knowledgebase-article/advanced-battery-cycling-with-methodscript/
@@ -79,37 +123,101 @@ class experimental_BatteryCycling(BaseModel):
     cell_on_ocp: bool = False
     """Turns cell on with the measured OCP (Nexus only)."""
 
-    power_frequency: Literal[50, 60] = 50
+    mains_frequency: Literal[50, 60] = 50
     """Set the DC mains filter in Hz.
 
     Adjusts sampling on instrument to account for mains frequency.
     Set to 50 Hz or 60 Hz depending on your region (default: 50)."""
 
     _name: str = 'Battery Cycling (experimental)'
+    _template: str = 'battery_cycling.mscr'
 
-    def render(self) -> str:
-        """Render the template with model parameters.
 
-        Returns
-        -------
-        script : str
-            Complete MethodScript code for this method.
-        """
-        template = env.get_template('battery_cycling.mscr')
-        return template.render(model=self, timestamp=datetime.today(), version=__version__)
+class ConstantResistance(BaseMethodScriptTechnique):
+    """Discharge at Constant Resistance load.
 
-    def to_methodscript(self) -> MethodScript:
-        """Convert to MethodSCRIPT class.
+    Note: This method is experimental and may be subject to change.
 
-        Returns
-        -------
-        method: MethodScript
-            MethodScript class.
-        """
-        script = self.render()
-        return MethodScript(script=script)
+    Supported devices:
 
-    def _to_psmethod(self) -> PalmSens.Method:
-        """Convert parameters to dotnet method."""
-        method = self.to_methodscript()
-        return method._to_psmethod()
+    - Nexus
+    - EmStat4 series (EmStat4S, EmStat4X, MultiEmStat4)
+
+    This method implements a single step for discharging a battery or
+    capacitor at a constant resistance load (Volt per Ampère). This
+    simulates the demand of very simple loads, like a filament lamp
+    or a simple DC motor. While the battery is discharging, its voltage
+    drops and the current provided also decreases in proportion to the
+    constant resistance. The applied current is refreshed at the defined
+    time interval. The discharge is finished when the lower target
+    voltage is reached (the lower cut-off voltage limit) or after the
+    defined duration.
+
+    Send live I-V versus time at a defined time interval.
+    The discharge current is converted to positive values."""
+
+    _name: str = 'Constant Resistance (experimental)'
+    _template: str = 'constant_resistance.mscr'
+
+    load: int = -80
+    """Constant resistance load in Ohm (make it negative for discharging)."""
+
+    cutoff: int = 2500
+    """A cut-off potential in mV to finish the discharge step."""
+
+    duration: int = Field(3600, ge=0)
+    """The total duration of the experiment in s (if the cut-off limit currents not met)."""
+
+    interval: int = Field(1, ge=0)
+    """The interval time in s of each data point."""
+
+    mains_frequency: Literal[50, 60] = 50
+    """Set the DC mains filter in Hz.
+
+    Adjusts sampling on instrument to account for mains frequency.
+    Set to 50 Hz or 60 Hz depending on your region (default: 50)."""
+
+
+class ConstantPower(BaseMethodScriptTechnique):
+    """Discharge at Constant Power.
+
+    Note: This method is experimental and may be subject to change.
+
+    Supported devices:
+
+    - Nexus
+    - EmStat4 series (EmStat4S, EmStat4X, MultiEmStat4)
+
+    This method implements a single step for discharging a battery or
+    capacitor at a constant power rate (Volt x Ampère). This simulates
+    the demand of electronic devices when performing a specific task,
+    i.e. a smartphone playing a video. While the battery is discharging,
+    its voltage drops and the demanded current increases in order to
+    maintain the set power. The applied current is refreshed at the defined
+    time interval. The discharge is finished when the lower target
+    voltage is reached (the lower cut-off voltage limit) or after
+    the defined duration.
+
+    Send live I-V versus time at a defined time interval.
+    The discharge current is converted to positive values."""
+
+    _name: str = 'Constant Power (experimental)'
+    _template: str = 'constant_power.mscr'
+
+    power: int = -200
+    """Constant power in Watt (negative for discharging)."""
+
+    cutoff: int = 2500
+    """A cut-off potential in mV to finish the discharge step."""
+
+    duration: int = Field(3600, ge=0)
+    """The total duration of the experiment in s (if the cut-off limit currents not met)."""
+
+    interval: int = Field(1, ge=0)
+    """The interval time in s of each data point."""
+
+    mains_frequency: Literal[50, 60] = 50
+    """Set the DC mains filter in Hz.
+
+    Adjusts sampling on instrument to account for mains frequency.
+    Set to 50 Hz or 60 Hz depending on your region (default: 50)."""

--- a/python/src/pypalmsens/energy.py
+++ b/python/src/pypalmsens/energy.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from ._methods.energy import (
-    experimental_BatteryCycling,
-)
+from ._methods.energy import BatteryCycling as experimental_BatteryCycling
+from ._methods.energy import ConstantPower as experimental_ConstantPower
+from ._methods.energy import ConstantResistance as experimental_ConstantResistance
 
 __all__ = [
     'experimental_BatteryCycling',
+    'experimental_ConstantPower',
+    'experimental_ConstantResistance',
 ]

--- a/python/src/pypalmsens/templates/battery_cycling.mscr
+++ b/python/src/pypalmsens/templates/battery_cycling.mscr
@@ -2,7 +2,6 @@ e
 # MethodSCRIPT version: 1.9
 # Generated on {{ timestamp }} by PyPalmSens {{ version }}
 #
-# Initialize variables. All variables must be declared before first use.
 var potential_max
 var potential_min
 var current_charge

--- a/python/src/pypalmsens/templates/battery_cycling.mscr
+++ b/python/src/pypalmsens/templates/battery_cycling.mscr
@@ -54,7 +54,7 @@ timer_start
 loop cycle <= cycles
     set_pgstat_mode 6
     set_max_bandwidth bandwidth
-    set_acquisition_frac_autoadjust {{ model.power_frequency }}
+    set_acquisition_frac_autoadjust {{ model.mains_frequency }}
     set_range_minmax ab potential_min potential_max
     set_autoranging ab potential_min potential_max
     set_range db current_charge
@@ -100,7 +100,7 @@ loop cycle <= cycles
     # Constant Voltage (CV) charge step. Many codes are similar to the CC charge step.
     set_pgstat_mode 3
     set_max_bandwidth bandwidth
-    set_acquisition_frac_autoadjust {{ model.power_frequency }}
+    set_acquisition_frac_autoadjust {{ model.mains_frequency }}
     set_range da potential_max
     set_range_minmax ba current_min current_charge
     set_autoranging ba current_min current_charge
@@ -142,7 +142,7 @@ loop cycle <= cycles
     # Constant current discharge. Codes below are almost the same as for the CC charge step.
     set_pgstat_mode 6
     set_max_bandwidth bandwidth
-    set_acquisition_frac_autoadjust {{ model.power_frequency }}
+    set_acquisition_frac_autoadjust {{ model.mains_frequency }}
     set_range_minmax ab potential_min potential_max
     set_autoranging ab potential_min potential_max
     set_range db current_discharge

--- a/python/src/pypalmsens/templates/constant_power.mscr
+++ b/python/src/pypalmsens/templates/constant_power.mscr
@@ -49,7 +49,9 @@ loop time <= duration
 			pck_add current
 		pck_end
 		if potential < cutoff
-		    abort
+		    send_string f"Cut-off limit reached."
+    		wait 5
+            abort
 		endif
 		send_string f"E = {potential} V    |    I = {current} A    |    t = {time} s"
 		set_script_output 0

--- a/python/src/pypalmsens/templates/constant_power.mscr
+++ b/python/src/pypalmsens/templates/constant_power.mscr
@@ -49,7 +49,7 @@ loop time <= duration
 			pck_add current
 		pck_end
 		if potential < cutoff
-			breakloop
+		    abort
 		endif
 		send_string f"E = {potential} V    |    I = {current} A    |    t = {time} s"
 		set_script_output 0

--- a/python/src/pypalmsens/templates/constant_power.mscr
+++ b/python/src/pypalmsens/templates/constant_power.mscr
@@ -1,0 +1,56 @@
+e
+# MethodSCRIPT version: 1.9
+# Generated on {{ timestamp }} by PyPalmSens {{ version }}
+#
+var current
+var potential
+var time
+var power
+var cutoff
+var sampling
+var duration
+var interval
+var app_current
+var bandwidth
+# set technique parameters
+store_var power {{ model.power }}m db # set constant power in Watts (negative for discharging)
+store_var cutoff {{ model.cutoff }}m ab # set a cut-off potential to finish the discharge step
+store_var duration {{ model.duration }} eb # set the total duration of the experiment (if the cut-off limit currents not met)
+store_var interval {{ model.interval }} eb # set the interval time of each data point
+# initialize the galvanostat
+store_var bandwidth 5850535u dc
+div_var bandwidth interval
+set_pgstat_chan 0
+set_pgstat_mode 6
+set_acquisition_frac_autoadjust {{ model.mains_frequency }}
+set_max_bandwidth bandwidth
+set_range ab 4200m
+set_autoranging ab 1m 4200m
+set_int interval
+meas 100m potential ab
+cell_on ocp(potential)
+# start the experiment
+timer_start
+loop time <= duration
+    copy_var power app_current
+    div_var app_current potential
+	set_range db app_current
+    meas_loop_cp potential current app_current interval interval
+		mul_var current -1
+		timer_get time
+		set_script_output 1
+		pck_start
+			pck_add time
+			pck_add potential
+			pck_add current
+		pck_end
+		if potential < cutoff
+			breakloop
+		endif
+		send_string f"E = {potential} V    |    I = {current} A    |    t = {time} s"
+		set_script_output 0
+	endloop
+endloop
+on_finished:
+  cell_off
+

--- a/python/src/pypalmsens/templates/constant_power.mscr
+++ b/python/src/pypalmsens/templates/constant_power.mscr
@@ -28,7 +28,11 @@ set_range ab 4200m
 set_autoranging ab 1m 4200m
 set_int interval
 meas 100m potential ab
+{% if model.cell_on_ocp -%}
 cell_on ocp(potential)
+{%else -%}
+cell_on
+{%endif -%}
 # start the experiment
 timer_start
 loop time <= duration

--- a/python/src/pypalmsens/templates/constant_resistance.mscr
+++ b/python/src/pypalmsens/templates/constant_resistance.mscr
@@ -28,7 +28,11 @@ set_range ab 4200m
 set_autoranging ab 42m 4200m
 set_int interval
 meas 100m potential ab
+{% if model.cell_on_ocp -%}
 cell_on ocp(potential)
+{%else -%}
+cell_on
+{%endif -%}
 # start the experiment
 loop time <= duration
     copy_var potential app_current

--- a/python/src/pypalmsens/templates/constant_resistance.mscr
+++ b/python/src/pypalmsens/templates/constant_resistance.mscr
@@ -1,0 +1,55 @@
+e
+# MethodSCRIPT version: 1.9
+# Generated on {{ timestamp }} by PyPalmSens {{ version }}
+#
+var current
+var potential
+var time
+var load
+var cutoff
+var sampling
+var duration
+var interval
+var app_current
+var bandwidth
+# set technique parameters
+store_var load {{ load }} db # set constant resistance load in Ohms (make it negative for discharging)
+store_var cutoff {{ cutoff }}m ab # set a cut-off potential to finish the discharge step
+store_var duration {{ duration }} eb # set the total duration of the experiment (if the cut-off limit currents not met)
+store_var interval {{ interval }} eb # set the interval time of each data point
+# initialize the galvanostat
+store_var bandwidth 5850535u dc
+div_var bandwidth interval
+set_pgstat_chan 0
+set_pgstat_mode 6
+set_acquisition_frac_autoadjust 50
+set_max_bandwidth bandwidth
+set_range ab 4200m
+set_autoranging ab 42m 4200m
+set_int interval
+meas 100m potential ab
+cell_on ocp(potential)
+# start the experiment
+loop time <= duration
+    copy_var potential app_current
+    div_var app_current load
+	set_range db app_current
+    meas_loop_cp potential current app_current interval interval
+		mul_var current -1
+		timer_get time
+		set_script_output 1
+		pck_start
+			pck_add time
+			pck_add potential
+			pck_add current
+		pck_end
+		if potential < cutoff
+			breakloop
+		endif
+		send_string f"E = {potential} V    |    I = {current} A    |    t = {time} s"
+		set_script_output 0
+	endloop
+endloop
+on_finished:
+  cell_off
+

--- a/python/src/pypalmsens/templates/constant_resistance.mscr
+++ b/python/src/pypalmsens/templates/constant_resistance.mscr
@@ -22,7 +22,7 @@ store_var bandwidth 5850535u dc
 div_var bandwidth interval
 set_pgstat_chan 0
 set_pgstat_mode 6
-set_acquisition_frac_autoadjust 50
+set_acquisition_frac_autoadjust {{ model.mains_frequency }}
 set_max_bandwidth bandwidth
 set_range ab 4200m
 set_autoranging ab 42m 4200m

--- a/python/src/pypalmsens/templates/constant_resistance.mscr
+++ b/python/src/pypalmsens/templates/constant_resistance.mscr
@@ -13,10 +13,10 @@ var interval
 var app_current
 var bandwidth
 # set technique parameters
-store_var load {{ load }} db # set constant resistance load in Ohms (make it negative for discharging)
-store_var cutoff {{ cutoff }}m ab # set a cut-off potential to finish the discharge step
-store_var duration {{ duration }} eb # set the total duration of the experiment (if the cut-off limit currents not met)
-store_var interval {{ interval }} eb # set the interval time of each data point
+store_var load {{ model.load }} db # set constant resistance load in Ohms (make it negative for discharging)
+store_var cutoff {{ model.cutoff }}m ab # set a cut-off potential to finish the discharge step
+store_var duration {{ model.duration }} eb # set the total duration of the experiment (if the cut-off limit currents not met)
+store_var interval {{ model.interval }} eb # set the interval time of each data point
 # initialize the galvanostat
 store_var bandwidth 5850535u dc
 div_var bandwidth interval

--- a/python/src/pypalmsens/templates/constant_resistance.mscr
+++ b/python/src/pypalmsens/templates/constant_resistance.mscr
@@ -48,7 +48,7 @@ loop time <= duration
 			pck_add current
 		pck_end
 		if potential < cutoff
-			breakloop
+		    abort
 		endif
 		send_string f"E = {potential} V    |    I = {current} A    |    t = {time} s"
 		set_script_output 0

--- a/python/src/pypalmsens/templates/constant_resistance.mscr
+++ b/python/src/pypalmsens/templates/constant_resistance.mscr
@@ -48,7 +48,9 @@ loop time <= duration
 			pck_add current
 		pck_end
 		if potential < cutoff
-		    abort
+    		send_string f"Cut-off limit reached."
+    		wait 5
+            abort
 		endif
 		send_string f"E = {potential} V    |    I = {current} A    |    t = {time} s"
 		set_script_output 0

--- a/python/tests/test_energy.py
+++ b/python/tests/test_energy.py
@@ -91,6 +91,20 @@ class DCP:
         assert measurement
         assert isinstance(measurement, ps.data.Measurement)
 
+        assert measurement.title == 'Constant Power'
+
+        curves = measurement.curves
+
+        assert len(curves) == 2
+
+        for curve in curves:
+            assert len(curve) == 2
+
+        dataset = measurement.dataset
+
+        assert dataset.array_names == {'AppliedCurrent1_2', 'Potential1_2', 'Time1_2'}
+        assert dataset.array_quantities == {'Time', 'Potential', 'Current'}
+
 
 class DCR:
     """Note: requires dummy circuit."""
@@ -105,6 +119,20 @@ class DCR:
     def validate(measurement):
         assert measurement
         assert isinstance(measurement, ps.data.Measurement)
+
+        assert measurement.title == 'Constant Resistance'
+
+        curves = measurement.curves
+
+        assert len(curves) == 2
+
+        for curve in curves:
+            assert len(curve) == 2
+
+        dataset = measurement.dataset
+
+        assert dataset.array_names == {'AppliedCurrent1_2', 'Potential1_2', 'Time1_2'}
+        assert dataset.array_quantities == {'Time', 'Potential', 'Current'}
 
 
 @pytest.mark.instrument

--- a/python/tests/test_energy.py
+++ b/python/tests/test_energy.py
@@ -38,6 +38,7 @@ class BC:
         'id': 'bc',
         'cycles': 1,
         'max_time': 1,
+        'cell_on_ocp': False,
     }
 
     @staticmethod
@@ -82,6 +83,7 @@ class DCP:
     kwargs = {
         'id': 'dcp',
         'duration': 3,
+        'cell_on_ocp': False,
     }
 
     @staticmethod
@@ -96,6 +98,7 @@ class DCR:
     kwargs = {
         'id': 'dcr',
         'duration': 3,
+        'cell_on_ocp': False,
     }
 
     @staticmethod

--- a/python/tests/test_energy.py
+++ b/python/tests/test_energy.py
@@ -75,10 +75,42 @@ class BC:
         assert dataset.array_quantities == {'Current', 'Potential', 'Time'}
 
 
+class DCP:
+    """Note: requires dummy circuit."""
+
+    kwargs = {
+        'id': 'dcp',
+        'duration': 3,
+    }
+
+    @staticmethod
+    def validate(measurement):
+        assert measurement
+        assert isinstance(measurement, ps.data.Measurement)
+
+
+class DCR:
+    """Note: requires dummy circuit."""
+
+    kwargs = {
+        'id': 'dcr',
+        'duration': 3,
+    }
+
+    @staticmethod
+    def validate(measurement):
+        assert measurement
+        assert isinstance(measurement, ps.data.Measurement)
+
+
 @pytest.mark.instrument
 @pytest.mark.parametrize(
     'method',
-    (BC,),
+    (
+        BC,
+        DCP,
+        DCR,
+    ),
 )
 def test_measure(manager, method):
     params = energy_technique_adapter.validate_python(method.kwargs)
@@ -91,7 +123,11 @@ def test_measure(manager, method):
 
 @pytest.mark.parametrize(
     'method',
-    (BC,),
+    (
+        BC,
+        DCP,
+        DCR,
+    ),
 )
 def test_params_round_trip(method):
     params = energy_technique_adapter.validate_python(method.kwargs)

--- a/python/tests/test_energy.py
+++ b/python/tests/test_energy.py
@@ -12,6 +12,7 @@ import pypalmsens as ps
 from pypalmsens._methods.adapters import (
     energy_technique_adapter,
 )
+from pypalmsens._methods.energy import BaseMethodScriptTechnique
 from pypalmsens.energy import experimental_BatteryCycling
 
 logger = logging.getLogger(__name__)
@@ -115,7 +116,7 @@ class DCR:
 def test_measure(manager, method):
     params = energy_technique_adapter.validate_python(method.kwargs)
 
-    assert isinstance(params, experimental_BatteryCycling)
+    assert isinstance(params, BaseMethodScriptTechnique)
 
     measurement = manager.measure(params)
     method.validate(measurement)

--- a/python/tests/test_energy.py
+++ b/python/tests/test_energy.py
@@ -170,5 +170,4 @@ def test_params_round_trip(method):
         ps.save_method_file(path, ms_params)
         new_params = ps.load_method_file(path)
 
-    # Skip header
-    assert new_params.script.splitlines()[4:] == params.render().splitlines()[4:]
+    assert new_params.script.splitlines() == params.render().splitlines()

--- a/python/zensical.toml
+++ b/python/zensical.toml
@@ -55,6 +55,8 @@ nav = [
   { "Techniques (energy)" = [
       "reference/energy/index.md",
       "reference/energy/battery_cycling.md",
+      "reference/energy/constant_power.md",
+      "reference/energy/constant_resistance.md",
   ]},
   { "Technique settings" = "reference/methods/settings.md" },
   { "Reference" = [


### PR DESCRIPTION
This PR adds ConstantResistance and ConstantPower methods to PyPalmSens.
Follows up from #376 

With constant power load:

```python
import pypalmsens as ps

method = ps.energy.ConstantPower(duration=10)
measurements = ps.measure(method, callback=print)
```

Or resistance load:

```python
import pypalmsens as ps

method = ps.energy.ConstantResistance(duration=10)
measurements = ps.measure(method, callback=print)
```

### TODO:

- [x] Improve tests
- [x] Add toggle for ocp(potential)
- [x] Update documentation
- [x] Find out why .render() passes if there is a mistake in the template e.g. {{ non_existant_variable }} -> https://jinja.palletsprojects.com/en/stable/api/#undefined-types
- [x] Reduce granularity of timestamp
- [x] Check if .NET measurement validate can find out if methodscript is valid