### PR TITLE
Add templates to MANIFEST.in

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,2 +1,3 @@
 # https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html
 graft src/pypalmsens/_libpalmsens/
+graft src/pypalmsens/templates/


### PR DESCRIPTION
This PR adds the templates to MANIFEST.in. These were missing from the wheel file in 1.10.0, causing a crash on import.

Closes #401 