### PR TITLE
Release python-1.10.1

### DIFF
--- a/docs/sdk/modules/ROOT/pages/releases.adoc
+++ b/docs/sdk/modules/ROOT/pages/releases.adoc
@@ -2,6 +2,7 @@ Releases
 ========
 
 // latest
+- https://github.com/palmsens/palmsens_sdk/releases/tag/python-1.10.1[python-1.10.1]
 - https://github.com/palmsens/palmsens_sdk/releases/tag/python-1.10[python-1.10]
 - https://github.com/palmsens/palmsens_sdk/releases/tag/python-1.9.0[python-1.9.0]
 - https://github.com/palmsens/palmsens_sdk/releases/tag/python-1.8.1[python-1.8.1]

--- a/python/docs/antora.yml
+++ b/python/docs/antora.yml
@@ -1,5 +1,5 @@
 name: python
-version: '1.10.0'
+version: '1.10.1'
 title: PyPalmSens
 start_page: index.adoc
 nav:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 [project]
 name = "PyPalmSens"
-version = "1.10.0"
+version = "1.10.1"
 description = "Python SDK for PalmSens instruments"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -137,7 +137,7 @@ enableTypeIgnoreComments = true
 reportIgnoreCommentWithoutRule = false
 
 [tool.bumpversion]
-current_version = "1.10.0"
+current_version = "1.10.1"
 
 [[tool.bumpversion.files]]
 filename = "src/pypalmsens/__init__.py"

--- a/python/src/pypalmsens/__init__.py
+++ b/python/src/pypalmsens/__init__.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from . import _libpalmsens
 
 __sdk_version__: str = _libpalmsens.load()
-__version__ = '1.10.0'
+__version__ = '1.10.1'
 
 from . import (
     corrosion,


### PR DESCRIPTION
This PR prepares for a new release of the python SDK.

- branch: `release-python-1.10.1`
- version: `1.10.1`
- sdk: `python`

# Release notes

PyPalmSens python-1.10.1 is now available on PyPi.

To upgrade: `pip install pypalmsens -U`.

For more information, see [the documentation](https://dev.palmsens.com/python/latest/_attachments/releases/#pypalmsens-1101)

## What's changed

- Fix changelog typos ([#398](https://github.com/PalmSens/PalmSens_SDK/pull/398))
- Fix changelog headers ([#399](https://github.com/PalmSens/PalmSens_SDK/pull/399))

**Full Changelog**: https://github.com/PalmSens/PalmSens_SDK/compare/python-1.10...python-1.10.1

