### PR TITLE
Implement receive message callback on InstrumentManager

### DIFF
--- a/python/docs/zensical/measuring.md
+++ b/python/docs/zensical/measuring.md
@@ -293,16 +293,12 @@ See [pypalmsens.data.Status][] or the provided [Status callback](examples.md#sta
 Likewise, you can register a callback for event messages.
 These are emitted when a measurement starts or for a `send_string` call in MethodSCRIPT.
 
-!!! NOTE "Async"
-
-    The callback requires an actizlve event loop and therefore only works in Async mode.
-
 For example, using print as the callback prints the messages to the terminal:
 
 ```python
 >>> method = ps.MethodScript(script=('wait 100m\nsend_string "Hello world"')
 >>> manager.register_receive_message_callback(print)
->>> await ps.measure_async(method)
+>>> await ps.measure(method)
 Running: MethodSCRIPT Sandbox
 Hello world
 >>> manager.unregister_receive_message_callback()

--- a/python/docs/zensical/measuring.md
+++ b/python/docs/zensical/measuring.md
@@ -288,6 +288,26 @@ Conditioning: potential=0.500 V, current=0.098 μA
 
 See [pypalmsens.data.Status][] or the provided [Status callback](examples.md#status-callback) example for more information.
 
+## Receive messages
+
+Likewise, you can register a callback for event messages.
+These are emitted when a measurement starts or for a `send_string` call in MethodSCRIPT.
+
+!!! NOTE "Async"
+
+    The callback requires an actizlve event loop and therefore only works in Async mode.
+
+For example, using print as the callback prints the messages to the terminal:
+
+```python
+>>> method = ps.MethodScript(script=('wait 100m\nsend_string "Hello world"')
+>>> manager.register_receive_message_callback(print)
+>>> await ps.measure_async(method)
+Running: MethodSCRIPT Sandbox
+Hello world
+>>> manager.unregister_receive_message_callback()
+```
+
 ## Manually controlling the device
 
 Depending on your device’s capabilities it can be used to set a potential/current and to switch current ranges.
@@ -349,13 +369,11 @@ More script features include:
 * Reading auxiliary values like pH or temperature
 * Going to sleep or hibernate mode
 
-See the [MethodSCRIPT™ documentation](https://www.palmsens.com/methodscript) for more information.
+See the [MethodSCRIPT™ documentation](https://dev.palmsens.com/msstart/methodscript_editors.html) for more information.
 
-### Sandbox Measurements
-
-PSTrace includes an option to make use MethodSCRIPT™ Sandbox to write and run scripts.
+PSTrace includes a MethodSCRIPT™ Editor to write and run scripts.
 This is a great place to test MethodSCRIPT™ measurements to see what the result would be.
-That script can then be used in the MethodScriptSandbox technique in the SDK as demonstrated below.
+That script can then be used in the [MethodScript][pypalmsens.MethodScript] technique in PyPalmSens.
 
 ![Graphical editor for MethodSCRIPT™](assets/method_script_editor.png){ width="80%" }
 

--- a/python/docs/zensical/measuring.md
+++ b/python/docs/zensical/measuring.md
@@ -304,6 +304,8 @@ Hello world
 >>> manager.unregister_receive_message_callback()
 ```
 
+See [InstrumentManager][pypalmsens.InstrumentManager.register_receive_message_callback] and [InstrumentManagerAsync][pypalmsens.InstrumentManagerAsync.register_receive_message_callback] for more information.
+
 ## Manually controlling the device
 
 Depending on your device’s capabilities it can be used to set a potential/current and to switch current ranges.

--- a/python/docs/zensical/measuring.md
+++ b/python/docs/zensical/measuring.md
@@ -291,9 +291,16 @@ See [pypalmsens.data.Status][] or the provided [Status callback](examples.md#sta
 ## Receive messages
 
 Likewise, you can register a callback for event messages.
-These are emitted when a measurement starts or for a `send_string` call in MethodSCRIPT.
 
-For example, using print as the callback prints the messages to the terminal:
+These messages are like those in the status bar in PSTrace, and can include messages like:
+
+- "Running: Cyclic Voltammetry"
+- "Measuring cycle _x_ level _y_" for multistep techniques
+- "Limit reached"
+
+These are also emitted for a `send_string` call in MethodSCRIPT.
+
+For example, using [print][] as the callback prints the messages to the terminal:
 
 ```python
 >>> method = ps.MethodScript(script=('wait 100m\nsend_string "Hello world"')

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -315,6 +315,8 @@ class InstrumentManager(CapabilitiesMixin):
         The callback is triggered, for example, when a method is started,
         or when `send_string` is called in MethodSCRIPT.
 
+        Parameters
+        ----------
         callback: Callable[[str], None]
             The function to call when triggered
         """

--- a/python/src/pypalmsens/_instruments/instrument_manager.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager.py
@@ -5,7 +5,7 @@ import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from time import sleep
-from typing import Generator
+from typing import Callable, Generator
 
 import clr
 import PalmSens
@@ -122,6 +122,7 @@ class InstrumentManager(CapabilitiesMixin):
         self.instrument: Instrument = instrument
         """Instrument being managed by this class."""
 
+        self._receive_message_callback: Callable[[str], None]
         self._comm: CommManager
 
     @override
@@ -307,6 +308,27 @@ class InstrumentManager(CapabilitiesMixin):
             serial = self._comm.DeviceSerial.ToString()
 
         return serial
+
+    def register_receive_message_callback(self, callback: Callable[[str], None], /):
+        """Register callback when a message is received.
+
+        The callback is triggered, for example, when a method is started,
+        or when `send_string` is called in MethodSCRIPT.
+
+        callback: Callable[[str], None]
+            The function to call when triggered
+        """
+        self._receive_message_callback = callback
+        self._comm.ClientConnection.ReceiveMessage += self._receive_message_handler
+
+    def unregister_receive_message_callback(self):
+        """Unregister callback from message events."""
+        self._comm.ClientConnection.ReceiveMessage -= self._receive_message_handler
+        del self._receive_message_callback
+
+    def _receive_message_handler(self, sender, message: str) -> None:
+        """Message handler helper function to schedule the callback."""
+        self._receive_message_callback(message)
 
     def measure(
         self,

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -6,11 +6,10 @@ import warnings
 from collections.abc import AsyncGenerator, Coroutine
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 import clr
 import PalmSens
-from PalmSens import AsyncEventHandler
 from PalmSens.Comm import CommManager, MuxType
 from System.Threading.Tasks import Task
 from typing_extensions import override
@@ -254,6 +253,7 @@ class InstrumentManagerAsync(CapabilitiesMixin):
 
         self._comm: CommManager
         self._status_callback: CallbackStatus
+        self._receive_message_callback: Callable[[str], None]
         self._loop: asyncio.AbstractEventLoop
 
     @override
@@ -460,11 +460,6 @@ class InstrumentManagerAsync(CapabilitiesMixin):
         """
         self._status_callback = callback
         self._loop = asyncio.get_running_loop()
-
-        self.status_idle_handler_async: AsyncEventHandler = AsyncEventHandler(
-            self._idle_status_handler
-        )
-
         self._comm.ReceiveStatusAsync += self._idle_status_handler
 
     def unregister_status_callback(self):
@@ -474,11 +469,32 @@ class InstrumentManagerAsync(CapabilitiesMixin):
 
     def _idle_status_handler(self, sender, args) -> Task.CompletedTask:
         """Event handler helper function to schedule the callback."""
-        assert self._status_callback
-
         status = Status._from_event_args(args)
 
         _ = self._loop.call_soon_threadsafe(self._status_callback, status)
+        return Task.CompletedTask
+
+    def register_receive_message_callback(self, callback: Callable[[str], None], /):
+        """Register callback when a message is received.
+
+        The callback is triggered, for example, when a method is started,
+        or when 'send_string' is called.
+
+        callback: Callable[[str], None]
+            The function to call when triggered
+        """
+        self._receive_message_callback = callback
+        self._loop = asyncio.get_running_loop()
+        self._comm.ClientConnection.ReceiveMessage += self._message_handler
+
+    def unregister_receive_message_callback(self):
+        """Unregister callback from message events."""
+        self._comm.ClientConnection.ReceiveMessage -= self._message_handler
+        del self._receive_message_callback
+
+    def _message_handler(self, sender, message: str) -> Task.CompletedTask:
+        """Message handler helper function to schedule the callback."""
+        _ = self._loop.call_soon_threadsafe(self._receive_message_callback, message)
         return Task.CompletedTask
 
     async def measure(

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -478,21 +478,21 @@ class InstrumentManagerAsync(CapabilitiesMixin):
         """Register callback when a message is received.
 
         The callback is triggered, for example, when a method is started,
-        or when 'send_string' is called.
+        or when `send_string` is called in MethodSCRIPT.
 
         callback: Callable[[str], None]
             The function to call when triggered
         """
         self._receive_message_callback = callback
         self._loop = asyncio.get_running_loop()
-        self._comm.ClientConnection.ReceiveMessage += self._message_handler
+        self._comm.ClientConnection.ReceiveMessage += self._receive_message_handler
 
     def unregister_receive_message_callback(self):
         """Unregister callback from message events."""
-        self._comm.ClientConnection.ReceiveMessage -= self._message_handler
+        self._comm.ClientConnection.ReceiveMessage -= self._receive_message_handler
         del self._receive_message_callback
 
-    def _message_handler(self, sender, message: str) -> Task.CompletedTask:
+    def _receive_message_handler(self, sender, message: str) -> Task.CompletedTask:
         """Message handler helper function to schedule the callback."""
         _ = self._loop.call_soon_threadsafe(self._receive_message_callback, message)
         return Task.CompletedTask

--- a/python/src/pypalmsens/_instruments/instrument_manager_async.py
+++ b/python/src/pypalmsens/_instruments/instrument_manager_async.py
@@ -455,6 +455,8 @@ class InstrumentManagerAsync(CapabilitiesMixin):
         The callback is triggered when the current/potential are updated
         durinig idle state or pretreatment phases.
 
+        Parameters
+        ----------
         callback: CallbackStatus
             The function to call when triggered
         """
@@ -480,6 +482,8 @@ class InstrumentManagerAsync(CapabilitiesMixin):
         The callback is triggered, for example, when a method is started,
         or when `send_string` is called in MethodSCRIPT.
 
+        Parameters
+        ----------
         callback: Callable[[str], None]
             The function to call when triggered
         """

--- a/python/tests/test_instrument.py
+++ b/python/tests/test_instrument.py
@@ -210,6 +210,31 @@ async def test_idle_status_callback_async():
 
 
 @pytest.mark.instrument
+@pytest.mark.asyncio
+async def test_message_callback_async():
+    points = []
+
+    def callback(message: str):
+        points.append(message)
+
+    async with await ps.connect_async() as manager:
+        manager.register_receive_message_callback(callback)
+
+        await asyncio.sleep(1)
+
+        method = method = ps.MethodScript(script=('wait 100m\nsend_string "Hello world"'))
+
+        _ = await manager.measure(method)
+        await asyncio.sleep(1)
+
+        manager.unregister_receive_message_callback()
+
+    assert len(points) == 2
+
+    assert points == ['Running: MethodSCRIPT Sandbox', 'Hello world']
+
+
+@pytest.mark.instrument
 def test_supported():
     instruments = ps.discover()
     with ps.connect(instruments[0]) as manager:

--- a/python/tests/test_instrument.py
+++ b/python/tests/test_instrument.py
@@ -210,6 +210,26 @@ async def test_idle_status_callback_async():
 
 
 @pytest.mark.instrument
+async def test_message_callback():
+    points = []
+
+    def callback(message: str):
+        points.append(message)
+
+    with ps.connect() as manager:
+        manager.register_receive_message_callback(callback)
+        method = method = ps.MethodScript(script=('wait 100m\nsend_string "Hello world"'))
+
+        _ = manager.measure(method)
+
+        manager.unregister_receive_message_callback()
+
+    assert len(points) == 2
+
+    assert points == ['Running: MethodSCRIPT Sandbox', 'Hello world']
+
+
+@pytest.mark.instrument
 @pytest.mark.asyncio
 async def test_message_callback_async():
     points = []
@@ -220,12 +240,9 @@ async def test_message_callback_async():
     async with await ps.connect_async() as manager:
         manager.register_receive_message_callback(callback)
 
-        await asyncio.sleep(1)
-
-        method = method = ps.MethodScript(script=('wait 100m\nsend_string "Hello world"'))
+        method = ps.MethodScript(script=('wait 100m\nsend_string "Hello world"'))
 
         _ = await manager.measure(method)
-        await asyncio.sleep(1)
 
         manager.unregister_receive_message_callback()
 


### PR DESCRIPTION
This PR adds support for the receive message callback to the `InstrumentManager(/Async)`.

These messages are like those in the status bar in PSTrace, and can include messages like:

- "Running: Cyclic Voltammetry"
- "Measuring cycle _x_ level _y_" for multistep techniques
- "Limit reached"

For example:

```python
>>> method = ps.MethodScript(script=('wait 100m\nsend_string "Hello world"')
>>> manager.register_receive_message_callback(print)
>>> await ps.measure(method)
Running: MethodSCRIPT Sandbox
Hello world
>>> manager.unregister_receive_message_callback()
```

Closes #384