### PR TITLE
Support custom units in MethodScript

### DIFF
--- a/python/src/pypalmsens/_instruments/measurement_manager_async.py
+++ b/python/src/pypalmsens/_instruments/measurement_manager_async.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import contextmanager
-from io import BytesIO
+from io import BufferedWriter
 from pathlib import Path
-from typing import Any, Callable, Generator, final
+from typing import Any, Callable, Generator
 
 import PalmSens
 import System
@@ -86,6 +86,101 @@ class MeasurementEvents:
 
     Use this to close files or clean up resources."""
 
+    def add_to(self, other: CallbackManager):
+        if self.on_error:
+            other.on_error.append(self.on_error)
+        if self.on_measurement_begin:
+            other.on_measurement_begin.append(self.on_measurement_begin)
+        if self.on_measurement_end:
+            other.on_measurement_end.append(self.on_measurement_end)
+        if self.on_curve_begin:
+            other.on_curve_begin.append(self.on_curve_begin)
+        if self.on_curve_new_data:
+            other.on_curve_new_data.append(self.on_curve_new_data)
+        if self.on_curve_end:
+            other.on_curve_end.append(self.on_curve_end)
+        if self.on_eis_data_begin:
+            other.on_eis_data_begin.append(self.on_eis_data_begin)
+        if self.on_eis_new_data:
+            other.on_eis_new_data.append(self.on_eis_new_data)
+        if self.on_eis_data_end:
+            other.on_eis_data_end.append(self.on_eis_data_end)
+        if self.setup:
+            other.setup.append(self.setup)
+        if self.teardown:
+            other.teardown.append(self.teardown)
+
+
+@dataclass(
+    kw_only=True,
+    config=ConfigDict(
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+    ),
+)
+class JSONWriter:
+    """Set up measurement events for streaming to JSON Lines format
+
+    More information: https://jsonlines.org/
+    """
+
+    filename: Path | str
+    """Path to stream to."""
+
+    _stream: BufferedWriter | None = None
+    _adapter: TypeAdapter[DataRow] = TypeAdapter(DataRow)
+
+    def add_to(self, other: CallbackManager):
+        other.on_measurement_begin.append(self.on_measurement_begin)
+        other.on_curve_begin.append(self.on_curve_begin)
+        other.on_curve_new_data.append(self.on_curve_new_data)
+        other.on_eis_data_begin.append(self.on_eis_data_begin)
+        other.on_eis_new_data.append(self.on_eis_new_data)
+        other.setup.append(self.setup)
+        other.teardown.append(self.teardown)
+
+    def on_measurement_begin(self, measurement: Measurement):
+        assert self._stream
+        _ = self._stream.write(measurement.metadata_json())
+        _ = self._stream.write(b'\n')
+
+        self._stream.flush()
+
+    def on_curve_begin(self, curve: Curve):
+        assert self._stream
+        _ = self._stream.write(curve.metadata_json())
+        _ = self._stream.write(b'\n')
+
+        self._stream.flush()
+
+    def on_curve_new_data(self, data: CallbackData):
+        assert self._stream
+        for row in data._streaming_rows():
+            _ = self._stream.write(self._adapter.dump_json(row))
+            _ = self._stream.write(b'\n')
+
+        self._stream.flush()
+
+    def on_eis_data_begin(self, eis_data: EISData):
+        assert self._stream
+        _ = self._stream.write(eis_data.metadata_json())
+        _ = self._stream.write(b'\n')
+        self._stream.flush()
+
+    def on_eis_new_data(self, data: CallbackDataEIS):
+        assert self._stream
+        for row in data._streaming_rows():
+            _ = self._stream.write(self._adapter.dump_json(row))
+            _ = self._stream.write(b'\n')
+        self._stream.flush()
+
+    def setup(self):
+        self._stream = open(self.filename, 'wb')
+
+    def teardown(self):
+        assert self._stream
+        self._stream.close()
+
 
 @dataclass(
     kw_only=True,
@@ -97,108 +192,16 @@ class CallbackManager:
     """Dataclass to manage callbacks."""
 
     on_error: list[Callable[[], None]] = Field(default_factory=list)
-    measurement_begin: list[Callable[[Measurement], None]] = Field(default_factory=list)
-    measurement_end: list[Callable[[], None]] = Field(default_factory=list)
-    curve_begin: list[Callable[[Curve], None]] = Field(default_factory=list)
-    curve_new_data: list[Callable[[CallbackData], None]] = Field(default_factory=list)
-    curve_end: list[Callable[[Curve], None]] = Field(default_factory=list)
-    eis_data_begin: list[Callable[[EISData], None]] = Field(default_factory=list)
-    eis_new_data: list[Callable[[CallbackDataEIS], None]] = Field(default_factory=list)
-    eis_data_end: list[Callable[[], None]] = Field(default_factory=list)
+    on_measurement_begin: list[Callable[[Measurement], None]] = Field(default_factory=list)
+    on_measurement_end: list[Callable[[], None]] = Field(default_factory=list)
+    on_curve_begin: list[Callable[[Curve], None]] = Field(default_factory=list)
+    on_curve_new_data: list[Callable[[CallbackData], None]] = Field(default_factory=list)
+    on_curve_end: list[Callable[[Curve], None]] = Field(default_factory=list)
+    on_eis_data_begin: list[Callable[[EISData], None]] = Field(default_factory=list)
+    on_eis_new_data: list[Callable[[CallbackDataEIS], None]] = Field(default_factory=list)
+    on_eis_data_end: list[Callable[[], None]] = Field(default_factory=list)
     setup: list[Callable[[], None]] = Field(default_factory=list)
     teardown: list[Callable[[], None]] = Field(default_factory=list)
-
-    def append(self, other: MeasurementEvents):
-        if other.on_error:
-            self.on_error.append(other.on_error)
-        if other.on_measurement_begin:
-            self.measurement_begin.append(other.on_measurement_begin)
-        if other.on_measurement_end:
-            self.measurement_end.append(other.on_measurement_end)
-        if other.on_curve_begin:
-            self.curve_begin.append(other.on_curve_begin)
-        if other.on_curve_new_data:
-            self.curve_new_data.append(other.on_curve_new_data)
-        if other.on_curve_end:
-            self.curve_end.append(other.on_curve_end)
-        if other.on_eis_data_begin:
-            self.eis_data_begin.append(other.on_eis_data_begin)
-        if other.on_eis_new_data:
-            self.eis_new_data.append(other.on_eis_new_data)
-        if other.on_eis_data_end:
-            self.eis_data_end.append(other.on_eis_data_end)
-        if other.setup:
-            self.setup.append(other.setup)
-        if other.teardown:
-            self.teardown.append(other.teardown)
-
-
-@final
-class JSONWriter(MeasurementEvents):
-    """Set up measurement events for streaming to JSON Lines format
-
-    More information: https://jsonlines.org/
-    """
-
-    filename: Path | str
-    """File to write to."""
-
-    _stream: BytesIO | None = None
-    _adapter: TypeAdapter[DataRow] = TypeAdapter(DataRow)
-
-    def __init__(self, filename: Path | str):
-
-        super().__init__()
-        self.filename = filename
-        self.on_measurement_begin = self._on_measurement_begin
-        self.on_curve_begin = self._on_curve_begin
-        self.on_curve_new_data = self._on_curve_new_data
-        self.on_eis_data_begin = self._on_eis_data_begin
-        self.on_eis_new_data = self._on_eis_new_data
-        self.setup = self._setup
-        self.teardown = self._teardown
-
-    def _on_measurement_begin(self, measurement: Measurement):
-        assert self._stream
-        _ = self._stream.write(measurement.metadata_json())
-        _ = self._stream.write(b'\n')
-
-        self._stream.flush()
-
-    def _on_curve_begin(self, curve: Curve):
-        assert self._stream
-        _ = self._stream.write(curve.metadata_json())
-        _ = self._stream.write(b'\n')
-
-        self._stream.flush()
-
-    def _on_curve_new_data(self, data: CallbackData):
-        assert self._stream
-        for row in data._streaming_rows():
-            _ = self._stream.write(self._adapter.dump_json(row))
-            _ = self._stream.write(b'\n')
-
-        self._stream.flush()
-
-    def _on_eis_data_begin(self, eis_data: EISData):
-        assert self._stream
-        _ = self._stream.write(eis_data.metadata_json())
-        _ = self._stream.write(b'\n')
-        self._stream.flush()
-
-    def _on_eis_new_data(self, data: CallbackDataEIS):
-        assert self._stream
-        for row in data._streaming_rows():
-            _ = self._stream.write(self._adapter.dump_json(row))
-            _ = self._stream.write(b'\n')
-        self._stream.flush()
-
-    def _setup(self):
-        self._stream = open(self.filename, 'wb')
-
-    def _teardown(self):
-        assert self._stream
-        self._stream.close()
 
 
 class MeasurementManagerAsync:
@@ -262,10 +265,10 @@ class MeasurementManagerAsync:
         self.comm.EndMeasurementAsync += self.end_measurement_handler
         self.comm.Disconnected += self.comm_error_handler
 
-        if self.callbacks.eis_new_data:
+        if self.callbacks.on_eis_new_data:
             self.comm.BeginReceiveEISData += self.begin_receive_eis_data_handler
 
-        if self.callbacks.curve_new_data:
+        if self.callbacks.on_curve_new_data:
             self.comm.BeginReceiveCurve += self.begin_receive_curve_handler
 
     def teardown(self):
@@ -274,10 +277,10 @@ class MeasurementManagerAsync:
         self.comm.EndMeasurementAsync -= self.end_measurement_handler
         self.comm.Disconnected -= self.comm_error_handler
 
-        if self.callbacks.eis_new_data:
+        if self.callbacks.on_eis_new_data:
             self.comm.BeginReceiveEISData -= self.begin_receive_eis_data_handler
 
-        if self.callbacks.curve_new_data:
+        if self.callbacks.on_curve_new_data:
             self.comm.BeginReceiveCurve -= self.begin_receive_curve_handler
 
         self.is_measuring = False
@@ -359,16 +362,16 @@ class MeasurementManagerAsync:
         self.callbacks = CallbackManager()
 
         if stream:
-            self.callbacks.append(JSONWriter(filename=stream))
+            JSONWriter(filename=stream).add_to(self.callbacks)
 
         if events:
-            self.callbacks.append(events)
+            events.add_to(self.callbacks)
 
         if callback:
             if method.id in ('eis', 'geis', 'fis', 'fgis'):
-                self.callbacks.eis_new_data.append(callback)  # type: ignore
+                self.callbacks.on_eis_new_data.append(callback)  # type: ignore
             else:
-                self.callbacks.curve_new_data.append(callback)  # type: ignore
+                self.callbacks.on_curve_new_data.append(callback)  # type: ignore
 
         with self._measurement_context():
             await self.await_measurement(method=psmethod, sync_event=sync_event)
@@ -390,7 +393,7 @@ class MeasurementManagerAsync:
 
         _ = self.loop.call_soon_threadsafe(self.begin_measurement_event.set)
 
-        for callback in self.callbacks.measurement_begin:
+        for callback in self.callbacks.on_measurement_begin:
             callback(measurement)
 
         return Task.CompletedTask
@@ -402,7 +405,7 @@ class MeasurementManagerAsync:
 
         _ = self.loop.call_soon_threadsafe(self.end_measurement_event.set)
 
-        for callback in self.callbacks.measurement_end:
+        for callback in self.callbacks.on_measurement_end:
             _ = self.loop.call_soon_threadsafe(callback)
 
         return Task.CompletedTask
@@ -421,7 +424,7 @@ class MeasurementManagerAsync:
             id=pscurve.GetHashCode(),
         )
 
-        for callback in self.callbacks.curve_new_data:
+        for callback in self.callbacks.on_curve_new_data:
             _ = self.loop.call_soon_threadsafe(callback, data)  # type: ignore
 
     def curve_finished_callback(
@@ -435,7 +438,7 @@ class MeasurementManagerAsync:
 
         curve = Curve(pscurve=pscurve)
 
-        for callback in self.callbacks.curve_end:
+        for callback in self.callbacks.on_curve_end:
             _ = self.loop.call_soon_threadsafe(callback, curve)  # type: ignore
 
     def begin_receive_curve_callback(
@@ -450,7 +453,7 @@ class MeasurementManagerAsync:
 
         curve = Curve(pscurve=pscurve)
 
-        for callback in self.callbacks.curve_begin:
+        for callback in self.callbacks.on_curve_begin:
             _ = self.loop.call_soon_threadsafe(callback, curve)  # type: ignore
 
     def eis_data_data_added_callback(self, eis_data: Plottables.EISData, args):
@@ -480,7 +483,7 @@ class MeasurementManagerAsync:
 
         self.eis_last_data_index = count
 
-        for callback in self.callbacks.eis_new_data:
+        for callback in self.callbacks.on_eis_new_data:
             _ = self.loop.call_soon_threadsafe(callback, data)  # type: ignore
 
     def eis_data_finished_callback(
@@ -492,7 +495,7 @@ class MeasurementManagerAsync:
         eis_data.NewDataAdded -= self.eis_data_data_added_handler
         eis_data.Finished -= self.eis_data_finished_handler
 
-        for callback in self.callbacks.eis_data_end:
+        for callback in self.callbacks.on_eis_data_end:
             _ = self.loop.call_soon_threadsafe(callback)  # type: ignore
 
     def begin_receive_eis_data_callback(
@@ -508,7 +511,7 @@ class MeasurementManagerAsync:
 
         data = EISData(pseis=eis_data)
 
-        for callback in self.callbacks.eis_data_begin:
+        for callback in self.callbacks.on_eis_data_begin:
             _ = self.loop.call_soon_threadsafe(callback, data)  # type: ignore
 
     def comm_error_callback(self, sender: PalmSens.Comm.CommManager, args: System.EventArgs):

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -21,7 +21,7 @@ env = Environment(
 
 class BaseMethodScriptTechnique(BaseModel):
     _template: str = ''
-    _custom_units: dict[Literal['as', 'at', 'au'], CustomUnits] = {}
+    _custom_units: dict[Literal['as', 'at', 'au'], CustomUnits] = Field(default_factory=dict)
 
     def render(self) -> str:
         """Render the template with model parameters.

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -8,6 +8,7 @@ from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescap
 from pydantic import BaseModel, Field
 
 from .. import __version__
+from .settings import CustomUnits
 from .techniques import MethodScript
 
 env = Environment(
@@ -20,6 +21,7 @@ env = Environment(
 
 class BaseMethodScriptTechnique(BaseModel):
     _template: str = ''
+    _custom_units: dict[Literal['as', 'at', 'au'], CustomUnits]
 
     def render(self) -> str:
         """Render the template with model parameters.
@@ -45,7 +47,8 @@ class BaseMethodScriptTechnique(BaseModel):
             MethodScript class.
         """
         script = self.render()
-        return MethodScript(script=script)
+
+        return MethodScript(script=script, custom_units=self._custom_units)
 
     def _to_psmethod(self) -> PalmSens.Method:
         """Convert parameters to dotnet method."""
@@ -93,6 +96,10 @@ class BatteryCycling(BaseMethodScriptTechnique):
 
     _name: str = 'Battery Cycling'
     _template: str = 'battery_cycling.mscr'
+    _custom_units = {
+        'as': CustomUnits(quantity='Passed Q', symbol='Qpass', unit='mAh'),
+        'at': CustomUnits(quantity='Cycle', symbol='cyc', unit='n'),
+    }
 
     id: Literal['bc'] = 'bc'
     """Unique method identifier."""

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 import PalmSens
 from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 from .. import __version__
 from .settings import CustomUnits
@@ -21,7 +21,9 @@ env = Environment(
 
 class BaseMethodScriptTechnique(BaseModel):
     _template: str = ''
-    _custom_units: dict[Literal['as', 'at', 'au'], CustomUnits] = Field(default_factory=dict)
+    _custom_units: dict[Literal['as', 'at', 'au'], CustomUnits] = PrivateAttr(
+        default_factory=dict
+    )
 
     def render(self) -> str:
         """Render the template with model parameters.

--- a/python/src/pypalmsens/_methods/energy.py
+++ b/python/src/pypalmsens/_methods/energy.py
@@ -21,7 +21,7 @@ env = Environment(
 
 class BaseMethodScriptTechnique(BaseModel):
     _template: str = ''
-    _custom_units: dict[Literal['as', 'at', 'au'], CustomUnits]
+    _custom_units: dict[Literal['as', 'at', 'au'], CustomUnits] = {}
 
     def render(self) -> str:
         """Render the template with model parameters.

--- a/python/src/pypalmsens/_methods/settings.py
+++ b/python/src/pypalmsens/_methods/settings.py
@@ -753,3 +753,14 @@ class Material(BaseSettings):
         self.density = psmethod.Density
         self.b_anodic = psmethod.Ba
         self.b_cathodic = psmethod.Bc
+
+
+class CustomUnits(BaseModel):
+    """Assign a custom unit to the AS / AT / AU variable types in MethodScript."""
+
+    quantity: str | None = None
+    """The full name to assign to the variable."""
+    symbol: str | None = None
+    """Abbreviation of the quantity."""
+    unit: str | None = None
+    """Abbreviation of the unit of the quantity."""

--- a/python/src/pypalmsens/_methods/techniques.py
+++ b/python/src/pypalmsens/_methods/techniques.py
@@ -35,6 +35,7 @@ from .mask import (
     get_extra_value_mask,
     set_extra_value_mask,
 )
+from .settings import CustomUnits
 
 
 class BaseCyclicVoltammetry(
@@ -2256,14 +2257,54 @@ endif
     For more info on MethodSCRIPT, see:
         https://www.palmsens.com/methodscript/ for more information."""
 
+    custom_units: dict[Literal['as', 'at', 'au'], CustomUnits] = Field(default_factory=dict)
+
     @override
     def _update_psmethod(self, psmethod: PalmSens.Method, /):
         """Update method with MethodScript."""
         psmethod.MethodScript = f'e\n{self.script}\n'
 
+        for name, unit in self.custom_units.items():
+            if name == 'as':
+                psmethod.OverrideUnitForASVarType = True
+                psmethod.CustomUnitASVarTypeQuantity = unit.quantity
+                psmethod.CustomUnitASVarTypeSymbol = unit.symbol
+                psmethod.CustomUnitASVarTypeUnit = unit.unit
+            elif name == 'at':
+                psmethod.OverrideUnitForATVarType = True
+                psmethod.CustomUnitATVarTypeQuantity = unit.quantity
+                psmethod.CustomUnitATVarTypeSymbol = unit.symbol
+                psmethod.CustomUnitATVarTypeUnit = unit.unit
+            elif name == 'au':
+                psmethod.OverrideUnitForAUVarType = True
+                psmethod.CustomUnitAUVarTypeQuantity = unit.quantity
+                psmethod.CustomUnitAUVarTypeSymbol = unit.symbol
+                psmethod.CustomUnitAUVarTypeUnit = unit.unit
+
     @override
     def _update_params(self, psmethod: PalmSens.Method, /):
         self.script = psmethod.MethodScript
+
+        if psmethod.OverrideUnitForATVarType:
+            self.custom_units['as'] = CustomUnits(
+                quantity=psmethod.CustomUnitASVarTypeQuantity,
+                symbol=psmethod.CustomUnitASVarTypeSymbol,
+                unit=psmethod.CustomUnitASVarTypeUnit,
+            )
+
+        if psmethod.OverrideUnitForATVarType:
+            self.custom_units['at'] = CustomUnits(
+                quantity=psmethod.CustomUnitATVarTypeQuantity,
+                symbol=psmethod.CustomUnitATVarTypeSymbol,
+                unit=psmethod.CustomUnitATVarTypeUnit,
+            )
+
+        if psmethod.OverrideUnitForAUVarType:
+            self.custom_units['au'] = CustomUnits(
+                quantity=psmethod.CustomUnitAUVarTypeQuantity,
+                symbol=psmethod.CustomUnitAUVarTypeSymbol,
+                unit=psmethod.CustomUnitAUVarTypeUnit,
+            )
 
     @classmethod
     def from_file(cls, path: str | Path = 'methodscript.mscr') -> MethodScript:

--- a/python/tests/test_energy.py
+++ b/python/tests/test_energy.py
@@ -67,8 +67,8 @@ class BC:
         expected_curves: list[dict[str, Any]] = [
             {'x': 'Time', 'y': 'Potential', 'min_len': 4},
             {'x': 'Time', 'y': 'Current', 'min_len': 4},
-            {'x': 'Potential', 'y': 'Potential', 'min_len': 1},
-            {'x': 'Potential', 'y': 'Potential', 'min_len': 1},
+            {'x': 'Cycle', 'y': 'Passed Q', 'min_len': 1},
+            {'x': 'Cycle', 'y': 'Passed Q', 'min_len': 1},
         ]
 
         curves = measurement.curves
@@ -92,7 +92,7 @@ class BC:
             'Potential1_2',
             'Time1_2',
         }
-        assert dataset.array_quantities == {'Current', 'Potential', 'Time'}
+        assert dataset.array_quantities == {'Current', 'Potential', 'Time', 'Passed Q', 'Cycle'}
 
 
 class DCP:

--- a/python/tests/test_instrument.py
+++ b/python/tests/test_instrument.py
@@ -210,7 +210,7 @@ async def test_idle_status_callback_async():
 
 
 @pytest.mark.instrument
-async def test_message_callback():
+def test_message_callback():
     points = []
 
     def callback(message: str):


### PR DESCRIPTION
This PR supports custom units to `pypalmsens.MethodScript`. The `BatteryCycling` technique uses this to specify custom units for the as/at variables.

Mimicks these settings in PSTrace:

<img width="357" height="418" alt="image" src="https://github.com/user-attachments/assets/ad5a0bee-216b-42c6-b410-bae1f4ea5773" />

Example:

```python
>>> import pypalmsens as ps
>>> method = ps.energy.experimental_BatteryCycling(cycles=1)
>>> measurements=ps.measure(method)
>>> measurements.curves
[Curve(title=CP: t vs E, n_points=18),
 Curve(title=CP: t vs i, n_points=18),
 Curve(title=Unknown: cyc vs Qpass, n_points=1),
 Curve(title=Unknown: cyc vs Qpass 1, n_points=1)]
```

Closes #413