### PR TITLE
Add reader for data stream

### DIFF
--- a/python/docs/zensical/measuring.md
+++ b/python/docs/zensical/measuring.md
@@ -506,10 +506,11 @@ See [Hardware sync](examples.md#multichannel_hw_sync) for a practical example.
 ## Streaming data to a file
 
 When measuring, PyPalmSens can auto-save all data directly to a file.
+The stream can be used for:
 
 1. Streaming data to other processes
 2. Data recovery
-3. Tracking Long-running measurements
+3. Tracking long-running measurements
 
 This option is especially useful for long-term measurements.
 Auto-saving all data helps with data recovery.
@@ -541,20 +542,47 @@ This means the data can be read in any programming language with a JSON parser.
 
     The data format was designed specifically for PyPalmSens. If you want to analyze your data in PSTrace, make sure to save the data to `.pssession` at the end of your measurement using [pypalmsens.save_session_file][].
 
+### Load stream data
+
+PyPalmSens contains a parser to load such files, [pypalmsens.load_stream_file][]. Although the data structure resembles that [pypalmsans.data.Measurement][], it it is much smaller in scope, and lacks some of the more advanced features.
+
+```python
+>>> import pypalmsens as ps
+
+>>> _ = ps.measure(ps.CyclicVoltammetry(n_scans=3), stream='data.jsonl')
+>>> stream = ps.load_stream_file('data.jsonl')
+>>> stream
+>>> Measurement(Cyclic Voltammetry, timestamp=2026-07-10 15:47:12, device=EmStat4LR)
+
+>>> stream.metadata.method
+CyclicVoltammetry(begin_potential=-0.5, vertex1_potential=0.5, vertex2_potential=-0.5, step_potential=0.1, scanrate=1.0, ...)
+
+>>> stream.curves
+Out[8]:
+[Curve(CV i vs E Scan 1, n_points=20),
+ Curve(CV i vs E Scan 2, n_points=20),
+ Curve(CV i vs E Scan 3, n_points=21)]
+
+>>> stream.curves[0].metadata
+>>> CurveMetadata(title='CV i vs E Scan 1', columns=['x', 'y'], units=['V', 'µA'], labels=['Potential', 'Current'], id=45011471, type='curve')
+
+>>> stream.curves[0].data
+[[-0.499999, -50.01226],
+ [-0.400011, -40.015384],
+ ...
+ [-0.300033, -29.950316],
+ [-0.400011, -40.018056]]
+ ```
+
 ### Data format
 
-The data are self-documenting. At the top of each file, PyPalmSens writes the Measurement metadata. This block contains the timestamp, device, method parameters, and firmware, and version information, version.
+The data are self-documenting. At the top of each file, PyPalmSens writes the Measurement metadata. This block contains the timestamp, device, method parameters, firmware version, and library version.
 
 For impedance measurements, the start of each EIS measurement starts with an 'EIS metadata' block. For non-impedance measurements, each curve starts with a Curve metadata block.
 
 These contain the title, column headers, units, labels, and other data metadata. The `id` field is used to link the data rows back to the curve or eis metadata.
 
 The majority of the lines will be rows of data, including an `id` field which can be used to match the corresponding curve / eis data and a `data` field containing a list of data values. The number of columns matches the `columns` / `units` / `quantities` lists in the metadata.
-
-<!--EISDataMetadata
-CurveMetadata
-MeasurementMetadata
-DataRow-->
 
 !!! Note "Feedback"
 

--- a/python/src/pypalmsens/__init__.py
+++ b/python/src/pypalmsens/__init__.py
@@ -67,6 +67,7 @@ from ._methods.techniques import (
     SquareWaveVoltammetry,
     StrippingChronoPotentiometry,
 )
+from ._stream import load_stream_file
 
 __all__ = [
     'corrosion',
@@ -83,6 +84,7 @@ __all__ = [
     'measure_async',
     'load_method_file',
     'load_session_file',
+    'load_stream_file',
     'save_method_file',
     'save_session_file',
     'stages',

--- a/python/src/pypalmsens/_data/measurement.py
+++ b/python/src/pypalmsens/_data/measurement.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Literal, final
 
 import System
-from pydantic import Field, TypeAdapter
+from pydantic import TypeAdapter
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from typing_extensions import override
 
@@ -58,12 +58,6 @@ class MeasurementMetadata:
     """Measurement title."""
     method: TechniqueType | EnergyTechniqueType
     """Method parameters."""
-    columns: list[str] = Field(default_factory=list)
-    """Column headers for data."""
-    units: list[str] = Field(default_factory=list)
-    """Column units."""
-    channels: int = 0
-    """Number of channels"""
     version_pypalmsens: str = __version__
     """PyPalmSens version."""
     version_sdk: str = __sdk_version__

--- a/python/src/pypalmsens/_stream.py
+++ b/python/src/pypalmsens/_stream.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, override
+
+from pydantic import Field, TypeAdapter
+from pydantic.dataclasses import dataclass
+
+from pypalmsens._data.curve import CurveMetadata
+from pypalmsens._data.eisdata import EISDataMetadata
+from pypalmsens._data.measurement import MeasurementMetadata
+from pypalmsens._instruments.callback import DataRow
+
+
+@dataclass
+class Curve:
+    metadata: CurveMetadata
+    data: list[list[float | int]] = Field(default_factory=list)
+
+    @override
+    def __repr__(self):
+        return f'{type(self).__name__}({self.metadata.title}, n_points={len(self.data)})'
+
+
+@dataclass
+class EISData:
+    metadata: EISDataMetadata
+    data: list[list[float | int]] = Field(default_factory=list)
+
+    @override
+    def __repr__(self):
+        return f'{type(self).__name__}({self.metadata.title}, n_points={len(self.data)})'
+
+
+@dataclass
+class Measurement:
+    metadata: MeasurementMetadata
+    curves: list[Curve] = Field(default_factory=list)
+    eis_data: list[EISData] = Field(default_factory=list)
+
+    @override
+    def __repr__(self):
+        return f'{type(self).__name__}({self.metadata.title}, timestamp={self.metadata.timestamp}, device={self.metadata.device.type})'
+
+
+def load_stream_file(path: str | Path) -> Measurement:
+    """Load JSON lines (filetype: jsonl) stream file.
+
+    See also: https://jsonlines.org/
+
+    Returns
+    -------
+    measurement : Measurement
+        Dataclass containing data from jsonl file.
+        The data structure mimicks `pypalmsens.data.measurement`.
+
+    """
+    measurement_metadata = None
+
+    data_rows = defaultdict(list)
+    curves_metadata = {}
+    eisdatas_metadata = {}
+
+    with open(path, encoding='utf-8') as lines:
+        for i, line in enumerate(lines):
+            parsed: Any = TypeAdapter(
+                DataRow | CurveMetadata | EISDataMetadata | MeasurementMetadata
+            ).validate_json(line)
+
+            if isinstance(parsed, DataRow):
+                data_rows[parsed.id].append(parsed.data)
+            elif isinstance(parsed, CurveMetadata):
+                curves_metadata[parsed.id] = parsed
+            elif isinstance(parsed, MeasurementMetadata):
+                measurement_metadata = parsed
+            elif isinstance(parsed, EISDataMetadata):
+                eisdatas_metadata[parsed.id] = parsed
+            else:
+                raise ValueError(f'Could not parse line {i}: {parsed}')
+
+    assert measurement_metadata
+
+    measurement = Measurement(metadata=measurement_metadata)
+
+    for curve_id, curve_metadata in curves_metadata.items():
+        data = [row for row in data_rows[curve_id]]
+        curve = Curve(metadata=curve_metadata, data=data)
+        measurement.curves.append(curve)
+
+    for eisdata_id, eisdata_metadata in eisdatas_metadata.items():
+        data = [row for row in data_rows[eisdata_id]]
+        eis_data = EISData(metadata=eisdata_metadata, data=data)
+        measurement.eis_data.append(eis_data)
+
+    return measurement

--- a/python/src/pypalmsens/_stream.py
+++ b/python/src/pypalmsens/_stream.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, override
+from typing import Any
 
 from pydantic import Field, TypeAdapter
 from pydantic.dataclasses import dataclass
+from typing_extensions import override
 
 from pypalmsens._data.curve import CurveMetadata
 from pypalmsens._data.eisdata import EISDataMetadata

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -1,71 +1,61 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import pytest
-from pydantic import TypeAdapter
 
 import pypalmsens as ps
-from pypalmsens._data.curve import CurveMetadata
-from pypalmsens._data.eisdata import EISDataMetadata
-from pypalmsens._data.measurement import MeasurementMetadata
-from pypalmsens._instruments.callback import DataRow
 from pypalmsens.types import MethodTypeCompatible
 
 
 def _test_stream(path: Path, method: MethodTypeCompatible):
     with ps.connect() as manager:
-        measurement = manager.measure(
+        measurement_ref = manager.measure(
             method,
             stream=Path(path),
         )
 
-    assert measurement
-
     assert path.exists()
-    lines = path.read_text(encoding='utf-8').splitlines()
 
-    assert lines
+    measurement = ps.load_stream_file(path)
 
-    curves = defaultdict(list)
-    curves_metadata = {}
-    measurement_metadata = None
+    curves = measurement.curves
 
-    for i, line in enumerate(lines):
-        parsed: Any = TypeAdapter(MeasurementMetadata | CurveMetadata | DataRow).validate_json(
-            line
-        )
+    assert len(curves) == len(measurement_ref.curves)
 
-        if isinstance(parsed, DataRow):
-            curves[parsed.id].append(parsed)
-        elif isinstance(parsed, CurveMetadata):
-            curves_metadata[parsed.id] = parsed
-        elif isinstance(parsed, MeasurementMetadata):
-            measurement_metadata = parsed
-            assert i == 0
-        else:
-            raise ValueError(f'This should not happen: {parsed}')
+    for curve, reference_curve in zip(measurement.curves, measurement_ref.curves):
+        assert curve.metadata.title == reference_curve.title
+        assert curve.metadata.units[0] == reference_curve.x_unit
+        assert curve.metadata.units[1] == reference_curve.y_unit
 
-    assert measurement_metadata
+        x, y = zip(*curve.data)
 
-    assert len(curves) == len(curves_metadata) == len(measurement.curves)
-    assert set(curves) == set(curves_metadata)
+        np.testing.assert_allclose(x, reference_curve.x_array)
+        np.testing.assert_allclose(y, reference_curve.y_array)
 
-    for curve in measurement.curves:
-        hash = curve._pscurve.GetHashCode()
+    for eis, eis_ref in zip(measurement.eis_data, measurement_ref.eis_data):
+        assert eis.metadata.title == eis_ref.title
+        assert eis.metadata.n_frequencies == eis_ref.n_frequencies
+        assert eis.metadata.frequency_type == eis_ref.frequency_type
+        assert eis.metadata.scan_type == eis_ref.scan_type
 
-        metadata = curves_metadata[hash]
-        assert metadata.title == curve.title
-        assert metadata.units[0] == curve.x_unit
-        assert metadata.units[1] == curve.y_unit
+        assert len(eis.data) == eis_ref.n_points
 
-        data = np.array([point.data for point in curves[hash]])
+        columns = list(eis.metadata.columns)
 
-        np.testing.assert_allclose(data[:, 0], curve.x_array)
-        np.testing.assert_allclose(data[:, 1], curve.y_array)
+        arrays_ref = {array.name: array for array in eis_ref.arrays()}
+
+        data = np.array(eis.data)
+
+        for i, col in enumerate(columns):
+            array_ref = arrays_ref[col]
+
+            assert array_ref.name == eis.metadata.columns[i]
+            assert array_ref.unit == eis.metadata.units[i]
+            assert array_ref.quantity == eis.metadata.quantities[i]
+
+            np.testing.assert_allclose(data[:, i], array_ref)
 
     return measurement
 
@@ -80,10 +70,13 @@ def test_measure_stream_cv_multiple_scans(tmpdir):
         scanrate=5,
         # use a fixed current range
         # because Measurement seems to do a post-processing step in a different CR ?
-        current_range='1uA',
+        current_range='1mA',
     )
 
-    _ = _test_stream(method=method, path=path)
+    measurement = _test_stream(method=method, path=path)
+
+    assert len(measurement.curves) == method.n_scans
+    assert not measurement.eis_data
 
 
 @pytest.mark.instrument
@@ -96,7 +89,10 @@ def test_measure_stream_cp_with_aux(tmpdir):
         record_we_current=True,
     )
 
-    _ = _test_stream(method=method, path=path)
+    measurement = _test_stream(method=method, path=path)
+
+    assert len(measurement.curves) == 3  # V, aux, we
+    assert not measurement.eis_data
 
 
 @pytest.mark.instrument
@@ -112,69 +108,7 @@ def test_measure_stream_eis(tmpdir):
         scan_type='potential',
     )
 
-    with ps.connect() as manager:
-        measurement = manager.measure(
-            method,
-            stream=Path(path),
-        )
+    measurement = _test_stream(method=method, path=path)
 
-    assert measurement
-
-    assert path.exists()
-    lines = path.read_text(encoding='utf-8').splitlines()
-
-    assert lines
-
-    eis_data_points = defaultdict(list)
-    eis_data = {}
-    measurement_metadata = None
-
-    for i, line in enumerate(lines):
-        parsed = TypeAdapter(MeasurementMetadata | EISDataMetadata | DataRow).validate_json(
-            line
-        )
-
-        if isinstance(parsed, DataRow):
-            eis_data_points[parsed.id].append(parsed)
-        elif isinstance(parsed, EISDataMetadata):
-            eis_data[parsed.id] = parsed
-        elif isinstance(parsed, MeasurementMetadata):
-            measurement_metadata = parsed
-            # This is a quirk of EIS measurements
-            # EISDataEvent is always after the first EISData.NewDataEvent
-            assert i == 1
-        else:
-            raise ValueError(f'This should not happen: {parsed}')
-
-    assert measurement_metadata
-
-    assert len(eis_data_points) == len(eis_data) == len(measurement.eis_data)
-    assert set(eis_data_points) == set(eis_data)
-
-    for eis in measurement.eis_data:
-        hash = eis._pseis.GetHashCode()
-
-        metadata = eis_data[hash]
-        assert metadata.title == eis.title
-        assert metadata.n_frequencies == eis.n_frequencies
-        assert metadata.frequency_type == eis.frequency_type
-        assert metadata.scan_type == eis.scan_type
-
-        points = eis_data_points[hash]
-
-        assert len(points) == eis.n_points
-
-        columns = list(metadata.columns)
-
-        arrays = {array.name: array for array in eis.arrays()}
-
-        data = np.array([point.data for point in points])
-
-        for i, col in enumerate(columns):
-            ref_array = arrays[col]
-
-            assert ref_array.name == metadata.columns[i]
-            assert ref_array.unit == metadata.units[i]
-            assert ref_array.quantity == metadata.quantities[i]
-
-            np.testing.assert_allclose(data[:, i], ref_array)
+    assert not measurement.curves
+    assert len(measurement.eis_data) == 1


### PR DESCRIPTION
This PR adds a reader for the streaming data.

```python
>>> import pypalmsens as ps

>>> _ = ps.measure(ps.CyclicVoltammetry(n_scans=3), stream='cv.jsonl')
>>> stream = ps.load_stream_file('cv.jsonl')
>>> stream
Measurement(Cyclic Voltammetry, timestamp=2026-07-10 15:47:12, device=EmStat4LR)

>>> stream.metadata.method
CyclicVoltammetry(begin_potential=-0.5, vertex1_potential=0.5, vertex2_potential=-0.5, step_potential=0.1, scanrate=1.0, ...)

>>> stream.curves
Out[8]:
[Curve(CV i vs E Scan 1, n_points=20),
 Curve(CV i vs E Scan 2, n_points=20),
 Curve(CV i vs E Scan 3, n_points=21)]

>>> stream.curves[0].metadata
>>> CurveMetadata(title='CV i vs E Scan 1', columns=['x', 'y'], units=['V', 'µA'], labels=['Potential', 'Current'], id=45011471, type='curve')

>>> stream.curves[0].data
[[-0.49998899999999996, -50.01226],
 [-0.400011, -40.015384],
 ...
 [-0.300033, -29.950315999999997],
 [-0.400011, -40.018056]]
```



Addresses #392